### PR TITLE
Conditionally `update_status` for `current_task`

### DIFF
--- a/sw_parser/tasks.py
+++ b/sw_parser/tasks.py
@@ -53,7 +53,7 @@ def com2us_data_import(data, user_id, import_options):
 
     results = parse_sw_json(data, summoner, import_options)
 
-    if current_task.request.id is not None:
+    if not current_task.request.called_directly:
         current_task.update_state(state=states.STARTED, meta={'step': 'summoner'})
 
     # Disconnect summoner profile last update post-save signal to avoid mass spamming updates
@@ -113,7 +113,7 @@ def com2us_data_import(data, user_id, import_options):
         # Set missing buildings to level 0
         BuildingInstance.objects.filter(owner=summoner).exclude(pk__in=[bldg.pk for bldg in results['buildings']]).update(level=0)
 
-    if current_task.request.id is not None:
+    if not current_task.request.called_directly:
         current_task.update_state(state=states.STARTED, meta={'step': 'monsters'})
 
     with transaction.atomic():
@@ -127,7 +127,7 @@ def com2us_data_import(data, user_id, import_options):
             piece.save()
             imported_pieces.append(piece.pk)
 
-    if current_task.request.id is not None:
+    if not current_task.request.called_directly:
         current_task.update_state(state=states.STARTED, meta={'step': 'runes'})
 
     with transaction.atomic():
@@ -139,7 +139,7 @@ def com2us_data_import(data, user_id, import_options):
             rune.save()
             imported_runes.append(rune.pk)
 
-    if current_task.request.id is not None:
+    if not current_task.request.called_directly:
         current_task.update_state(state=states.STARTED, meta={'step': 'crafts'})
 
     with transaction.atomic():

--- a/sw_parser/tasks.py
+++ b/sw_parser/tasks.py
@@ -53,7 +53,8 @@ def com2us_data_import(data, user_id, import_options):
 
     results = parse_sw_json(data, summoner, import_options)
 
-    current_task.update_state(state=states.STARTED, meta={'step': 'summoner'})
+    if current_task.request.id is not None:
+        current_task.update_state(state=states.STARTED, meta={'step': 'summoner'})
 
     # Disconnect summoner profile last update post-save signal to avoid mass spamming updates
     post_save.disconnect(update_profile_date, sender=MonsterInstance)
@@ -112,7 +113,8 @@ def com2us_data_import(data, user_id, import_options):
         # Set missing buildings to level 0
         BuildingInstance.objects.filter(owner=summoner).exclude(pk__in=[bldg.pk for bldg in results['buildings']]).update(level=0)
 
-    current_task.update_state(state=states.STARTED, meta={'step': 'monsters'})
+    if current_task.request.id is not None:
+        current_task.update_state(state=states.STARTED, meta={'step': 'monsters'})
 
     with transaction.atomic():
         # Save the imported monsters
@@ -125,7 +127,8 @@ def com2us_data_import(data, user_id, import_options):
             piece.save()
             imported_pieces.append(piece.pk)
 
-    current_task.update_state(state=states.STARTED, meta={'step': 'runes'})
+    if current_task.request.id is not None:
+        current_task.update_state(state=states.STARTED, meta={'step': 'runes'})
 
     with transaction.atomic():
         # Save imported runes
@@ -136,7 +139,8 @@ def com2us_data_import(data, user_id, import_options):
             rune.save()
             imported_runes.append(rune.pk)
 
-    current_task.update_state(state=states.STARTED, meta={'step': 'crafts'})
+    if current_task.request.id is not None:
+        current_task.update_state(state=states.STARTED, meta={'step': 'crafts'})
 
     with transaction.atomic():
         # Save imported rune crafts


### PR DESCRIPTION
I'm using simple tests to make sure my new code works.  I needed to call `com2us_data_import` in the `setUp` for one of those test.  Unfortunately, `current_task.update_state` errors in a task run locally/synchronously.  This PR wraps update calls in a check to make sure they only run in a worker-based environment.