### PR TITLE
Average Efficiency

### DIFF
--- a/bestiary/models.py
+++ b/bestiary/models.py
@@ -1648,7 +1648,7 @@ class Rune(models.Model, RuneObjectBase):
         # All runes are compared against max stat values for perfect 6* runes.
 
         # Main stat efficiency (max 100%)
-        running_sum = float(self.MAIN_STAT_VALUES[self.main_stat][self.stars][15]) / float(self.MAIN_STAT_VALUES[self.main_stat][6][15])
+        running_sum = float(self.MAIN_STAT_VALUES[self.main_stat][self.stars][15]) / float(self.MAIN_STAT_VALUES[self.main_stat][6][15])  # * factor[self.innate_stat]
 
         # Substat efficiencies (max 20% per; 1 innate, max 4 initial, 4 upgrades)
         if self.innate_stat is not None:
@@ -1681,7 +1681,7 @@ class Rune(models.Model, RuneObjectBase):
             available_stats = [
                 upgrade_value[self.stars] * factor[stat]
                 for stat, upgrade_value in self.UPGRADE_VALUES_MAX.items()
-                if stat not in self.substats
+                if stat not in self.substats and stat != self.main_stat and stat != self.innate_stat
             ]
             max_stats = sorted(available_stats, reverse=True)
             running_sum += sum(max_stats[:new_stats]) * 0.2 / 2.8 * 100
@@ -1710,7 +1710,7 @@ class Rune(models.Model, RuneObjectBase):
             available_stats = [
                 upgrade_value[self.stars] * factor[stat]
                 for stat, upgrade_value in self.UPGRADE_VALUES_AVG.items()
-                if stat not in self.substats
+                if stat not in self.substats and stat != self.main_stat and stat != self.innate_stat
             ]
             ave_stat = sum(available_stats) / len(available_stats)
             running_sum += ave_stat * new_stats * 0.2 / 2.8 * 100

--- a/bestiary/models.py
+++ b/bestiary/models.py
@@ -1685,7 +1685,7 @@ class Rune(models.Model, RuneObjectBase):
 
         return running_sum
 
-    def get_avg_efficiency(self, efficiency, substat_upgrades_remaining):
+    def get_avg_efficiency(self, efficiency=None, substat_upgrades_remaining=None):
         running_sum = efficiency if efficiency is not None else self.efficiency
         substat_upgrades_remaining = substat_upgrades_remaining if substat_upgrades_remaining is not None else \
             self.substat_upgrades_remaining

--- a/bestiary/models.py
+++ b/bestiary/models.py
@@ -1643,7 +1643,7 @@ class Rune(models.Model, RuneObjectBase):
     def substat_upgrades_received(self):
         return int(floor(min(self.level, 12) / 3) + 1)
 
-    def get_efficiency(self, scale=SUBSTAT_INCREMENTS):
+    def get_efficiency(self):
         # https://www.youtube.com/watch?v=SBWeptNNbYc
         # All runes are compared against max stat values for perfect 6* runes.
 
@@ -1652,14 +1652,14 @@ class Rune(models.Model, RuneObjectBase):
 
         # Substat efficiencies (max 20% per; 1 innate, max 4 initial, 4 upgrades)
         if self.innate_stat is not None:
-            running_sum += self.innate_stat_value / float(scale[self.innate_stat][6]) * 0.2
+            running_sum += self.innate_stat_value / float(self.SUBSTAT_INCREMENTS[self.innate_stat][6]) * 0.2
 
         for substat, value in zip(self.substats, self.substat_values):
-            running_sum += value / float(scale[substat][6]) * 0.2
+            running_sum += value / float(self.SUBSTAT_INCREMENTS[substat][6]) * 0.2
 
         return running_sum / 2.8 * 100
 
-    def get_max_efficiency(self, efficiency=None, substat_upgrades_remaining=None, scale=UPGRADE_VALUES_MAX):
+    def get_max_efficiency(self, efficiency=None, substat_upgrades_remaining=None):
         running_sum = efficiency if efficiency is not None else self.efficiency
         substat_upgrades_remaining = substat_upgrades_remaining if substat_upgrades_remaining is not None else \
             self.substat_upgrades_remaining
@@ -1668,7 +1668,7 @@ class Rune(models.Model, RuneObjectBase):
         old_stats = substat_upgrades_remaining - new_stats
 
         if old_stats > 0:
-            upgrades = [scale[stat][self.stars] for stat in self.substats]
+            upgrades = [self.UPGRADE_VALUES_MAX[stat][self.stars] for stat in self.substats]
             # we can repeatedly upgrade the most value of the existing stats
             max_stat = max(*upgrades, 0)  # use 0 to ensure max() doesn't error if we only have one stat
             running_sum += max_stat * old_stats * 0.2 / 2.8 * 100
@@ -1677,7 +1677,7 @@ class Rune(models.Model, RuneObjectBase):
             # add the top N stats
             available_stats = [
                 upgrade_value[self.stars]
-                for stat, upgrade_value in scale.items()
+                for stat, upgrade_value in self.UPGRADE_VALUES_MAX.items()
                 if stat not in self.substats
             ]
             max_stats = sorted(available_stats, reverse=True)
@@ -1685,7 +1685,7 @@ class Rune(models.Model, RuneObjectBase):
 
         return running_sum
 
-    def get_avg_efficiency(self, efficiency, substat_upgrades_remaining, scale=UPGRADE_VALUES_AVG):
+    def get_avg_efficiency(self, efficiency, substat_upgrades_remaining):
         running_sum = efficiency if efficiency is not None else self.efficiency
         substat_upgrades_remaining = substat_upgrades_remaining if substat_upgrades_remaining is not None else \
             self.substat_upgrades_remaining
@@ -1694,7 +1694,7 @@ class Rune(models.Model, RuneObjectBase):
         old_stats = substat_upgrades_remaining - new_stats
 
         if old_stats > 0:
-            upgrades = [scale[stat][self.stars] for stat in self.substats]
+            upgrades = [self.UPGRADE_VALUES_AVG[stat][self.stars] for stat in self.substats]
             # average value of an upgrade
             ave_stat = sum(upgrades) / len(upgrades)
             running_sum += ave_stat * old_stats * 0.2 / 2.8 * 100
@@ -1703,7 +1703,7 @@ class Rune(models.Model, RuneObjectBase):
             # average the missing stats
             available_stats = [
                 upgrade_value[self.stars]
-                for stat, upgrade_value in scale.items()
+                for stat, upgrade_value in self.UPGRADE_VALUES_AVG.items()
                 if stat not in self.substats
             ]
             ave_stat = sum(available_stats) / len(available_stats)

--- a/herders/tests/test_rune_instance.py
+++ b/herders/tests/test_rune_instance.py
@@ -84,7 +84,7 @@ class Efficiencies(TestCase):
             (1.0 + 4 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
         )
-        upgrades_level_6 = [v[6] for v in rune.UPGRADE_VALUES_AVG.values()]
+        upgrades_level_6 = [v[6] for stat, v in rune.UPGRADE_VALUES_AVG.items() if stat != rune.main_stat]
         self.assertAlmostEqual(
             (1.0 + 4 * 0.2 * sum(upgrades_level_6) / len(upgrades_level_6)) / 2.8 * 100,
             rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
@@ -135,7 +135,7 @@ class Efficiencies(TestCase):
             (51 / 63 + 2 * 0.875 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
         )
-        upgrades_level_5 = [v[5] for v in rune.UPGRADE_VALUES_AVG.values()]
+        upgrades_level_5 = [v[5] for stat, v in rune.UPGRADE_VALUES_AVG.items() if stat != rune.main_stat]
         self.assertAlmostEqual(
             (51 / 63 + 2 * 0.2 * sum(upgrades_level_5) / len(upgrades_level_5)) / 2.8 * 100,
             rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
@@ -188,7 +188,7 @@ class Efficiencies(TestCase):
             rune.max_efficiency,
         )
         # two average upgrades
-        upgrades_level_4 = [v[4] for v in rune.UPGRADE_VALUES_AVG.values()]
+        upgrades_level_4 = [v[4] for stat, v in rune.UPGRADE_VALUES_AVG.items() if stat != rune.main_stat]
         self.assertAlmostEqual(
             (43 / 63 + 2 * 0.2 * sum(upgrades_level_4) / len(upgrades_level_4)) / 2.8 * 100,
             rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),

--- a/herders/tests/test_rune_instance.py
+++ b/herders/tests/test_rune_instance.py
@@ -47,6 +47,10 @@ class Efficiencies(TestCase):
             1.0 / 2.8 * 100,
             rune.max_efficiency,
         )
+        self.assertAlmostEqual(
+            1.0 / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
+        )
 
     def test_efficiencies_star_6_level_12(self):
         """No upgrades are left so this should match the max level test"""
@@ -62,6 +66,10 @@ class Efficiencies(TestCase):
             1.0 / 2.8 * 100,
             rune.max_efficiency,
         )
+        self.assertAlmostEqual(
+            1.0 / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
+        )
 
     def test_efficiencies_star_6_level_0(self):
         rune = self.stub_rune(level=0)
@@ -75,6 +83,11 @@ class Efficiencies(TestCase):
         self.assertAlmostEqual(
             (1.0 + 4 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
+        )
+        upgrades_level_6 = [v[6] for v in rune.UPGRADE_VALUES_AVG.values()]
+        self.assertAlmostEqual(
+            (1.0 + 4 * 0.2 * sum(upgrades_level_6) / len(upgrades_level_6)) / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
         )
 
     def test_efficiencies_star_5_level_0_existing(self):
@@ -101,8 +114,15 @@ class Efficiencies(TestCase):
             (51 / 63 + 4 * 0.875 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
         )
+        # four upgrades to existing runes
+        upgrades = [rune.UPGRADE_VALUES_AVG[rune.STAT_HP_PCT][5], rune.UPGRADE_VALUES_AVG[rune.STAT_ATK_PCT][5],
+                    rune.UPGRADE_VALUES_AVG[rune.STAT_DEF_PCT][5], rune.UPGRADE_VALUES_AVG[rune.STAT_HP][5]]
+        self.assertAlmostEqual(
+            (51 / 63 + 4 * 0.2 * sum(upgrades) / len(upgrades)) / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
+        )
 
-    def test_efficiencies_star_5_level_0_new_base(self):
+    def test_efficiencies_star_5_level_6_new_base(self):
         rune = self.stub_rune(level=6, stars=5)
         rune.save()
 
@@ -114,6 +134,11 @@ class Efficiencies(TestCase):
         self.assertAlmostEqual(
             (51 / 63 + 2 * 0.875 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
+        )
+        upgrades_level_5 = [v[5] for v in rune.UPGRADE_VALUES_AVG.values()]
+        self.assertAlmostEqual(
+            (51 / 63 + 2 * 0.2 * sum(upgrades_level_5) / len(upgrades_level_5)) / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
         )
 
     def test_efficiencies_star_4_level_0_existing(self):
@@ -140,6 +165,13 @@ class Efficiencies(TestCase):
             (43 / 63 + 4 * 0.75 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
         )
+        # four upgrades to existing runes
+        upgrades = [rune.UPGRADE_VALUES_AVG[rune.STAT_HP_PCT][4], rune.UPGRADE_VALUES_AVG[rune.STAT_ATK_PCT][4],
+                    rune.UPGRADE_VALUES_AVG[rune.STAT_DEF_PCT][4], rune.UPGRADE_VALUES_AVG[rune.STAT_HP][4]]
+        self.assertAlmostEqual(
+            (43 / 63 + 4 * 0.2 * sum(upgrades) / len(upgrades)) / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
+        )
 
     def test_efficiencies_star_4_level_6_new_base(self):
         """Two upgrades left; a 4* should get the (max) base % upgrades"""
@@ -154,6 +186,12 @@ class Efficiencies(TestCase):
         self.assertAlmostEqual(
             (43 / 63 + 2 * 0.75 * 0.2) / 2.8 * 100,
             rune.max_efficiency,
+        )
+        # two average upgrades
+        upgrades_level_4 = [v[4] for v in rune.UPGRADE_VALUES_AVG.values()]
+        self.assertAlmostEqual(
+            (43 / 63 + 2 * 0.2 * sum(upgrades_level_4) / len(upgrades_level_4)) / 2.8 * 100,
+            rune.get_avg_efficiency(rune.efficiency, rune.substat_upgrades_remaining),
         )
 
     def test_efficiencies_star_4_level_9_new_base(self):


### PR DESCRIPTION
As I mentioned in #100, efficiency increase and max efficiency decreases as a rune's level increases.  This PR adds infrastructure for the **average** efficiency of a fully leveled rune.  I didn't want to add a model field or migrations so I commented the one line where the method would be called.  In the meantime, I added tests that directly call the function that calculates the values.  I can submit a separate PR exposing the value in the UI if you accept this PR, add the field, and generate authoritative migrations.

This PR also changes the `max` and `avg` functions to accept a `scale`.  The scale could be used e.g. to change the weights of the different attributes, mirroring the new SWOP feature.  Obviously, nothing in this PR actually takes advantage of it.