### PR TITLE
Implement BattleDungeonResult_V2

### DIFF
--- a/data_log/game_commands.py
+++ b/data_log/game_commands.py
@@ -73,6 +73,10 @@ active_log_commands = {
         schemas.battle_dungeon_result,
         models.DungeonLog.parse_dungeon_result
     ),
+    'BattleDungeonResult_V2': GameApiCommand(
+        schemas.battle_dungeon_result_v2,
+        models.DungeonLog.parse_dungeon_result_v2
+    ),
     'BattleRiftDungeonResult': GameApiCommand(
         schemas.battle_rift_dungeon_result,
         models.RiftDungeonLog.parse_rift_dungeon_result

--- a/data_log/models/log_models.py
+++ b/data_log/models/log_models.py
@@ -696,6 +696,55 @@ class DungeonLog(LogEntry):
             sd_reward.save()
 
     @classmethod
+    def parse_dungeon_result_v2(cls, summoner, log_data):
+        dungeon_id = log_data['request']['dungeon_id']
+        floor = log_data['request']['stage_id']
+
+        # Don't log HoH dungeons, which have IDs starting from 10000 and increments by 1 each new HoH.
+        if 10000 <= dungeon_id < 11000:
+            return
+
+        log_entry = cls(summoner=summoner)
+        log_entry.parse_common_log_data(log_data)
+        try:
+            log_entry.level = Level.objects.get(
+                dungeon__category=Dungeon.CATEGORY_CAIROS,
+                dungeon__com2us_id=dungeon_id,
+                floor=floor,
+            )
+        except Level.DoesNotExist:
+            # Create a placeholder level for later updating
+            try:
+                d = Dungeon.objects.get(category=Dungeon.CATEGORY_CAIROS, com2us_id=dungeon_id)
+            except Dungeon.DoesNotExist:
+                # Create the dungeon
+                d = Dungeon.objects.create(
+                    com2us_id=dungeon_id,
+                    enabled=False,
+                    name='UNKNOWN DUNGEON',
+                    category=Dungeon.CATEGORY_CAIROS,
+                )
+
+            # Create the level
+            log_entry.level = Level.objects.create(
+                dungeon=d,
+                floor=floor,
+            )
+            mail_admins('New Level Created', f'New level {floor} created in dungeon com2us ID {dungeon_id}.')
+
+        log_entry.success = log_data['request']['win_lose'] == 1
+        log_entry.clear_time = timedelta(milliseconds=log_data['request']['clear_time'])
+        log_entry.save()
+        log_entry.parse_rewards(log_data['response']['reward'])
+
+        # Parse secret dungeon drop
+        sd_info = log_data['response'].get('instance_info')
+        if sd_info:
+            sd_reward = DungeonSecretDungeonDrop.parse(sd_info)
+            sd_reward.log = log_entry
+            sd_reward.save()
+
+    @classmethod
     def parse_dimension_hole_result(cls, summoner, log_data):
         if log_data['response']['practice_mode']:
             # Don't parse practice modes

--- a/data_log/schemas.py
+++ b/data_log/schemas.py
@@ -332,6 +332,49 @@ battle_dungeon_result = {
     'required': ['request', 'response'],
 }
 
+battle_dungeon_result_v2 = {
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'id': 'http://swarfarm.com/schemas/battle_dungeon_result_v2.json',
+    'title': 'battle_dungeon_result_v2',
+    'type': 'object',
+    'properties': {
+        'request': {
+            'type': 'object',
+            'properties': {
+                'wizard_id': {'type': 'number'},
+                'command': {'type': 'string'},
+                'dungeon_id': {'type': 'number'},
+                'stage_id': {'type': 'number'},
+                'win_lose': {'type': 'number'},
+                'clear_time': {'type': 'number'},
+            },
+            'required': [
+                'wizard_id',
+                'command',
+                'dungeon_id',
+                'stage_id',
+                'win_lose',
+                'clear_time',
+            ],
+        },
+        'response': {
+            'type': 'object',
+            'properties': {
+                'tzone': {'type': 'string'},
+                'tvalue': {'type': 'number'},
+                'reward': {'type': 'object'},
+                'instance_info': {'type': ['null', 'object']}
+            },
+            'required': [
+                'tzone',
+                'tvalue',
+                'reward',
+            ]
+        }
+    },
+    'required': ['request', 'response'],
+}
+
 battle_rift_dungeon_result = {
     '$schema': 'http://json-schema.org/draft-04/schema#',
     'id': 'http://swarfarm.com/schemas/battle_rift_dungeon_result.json',


### PR DESCRIPTION
This is the first, naive try to implement the new `BattleDungeonResult_V2` packet implemented by Com2Us.
It seemingly does only add new fields without removing any that we are using, which is why the existing code that should still work for the new packet is mostly just duplicated.

**I could not test any of this locally because I could not get the development environment to run, so please verify first if this can work before merging.**