### PR TITLE
Live Sync Bugfixes & Verad preprocess

### DIFF
--- a/bestiary/parse/skills.py
+++ b/bestiary/parse/skills.py
@@ -149,8 +149,13 @@ def skills():
 
 
 # Skill erratum
-def replace_attack_def_with_just_def(raw):
+def replace_golem_multiplier(raw):
     raw['fun data'] = [["ATK", "*", 1.8], ["+"], ["DEF", "*", 2.5]]
+    return raw
+
+
+def replace_attack_def_with_just_def(raw):
+    raw['fun data'] = [[el.replace('ATTACK_DEF', 'DEF') if isinstance(el, str) else el for el in row] for row in raw['fun data']]
     return raw
 
 
@@ -185,15 +190,16 @@ def remove_multiplier(raw):
 
 
 _preprocess_erratum = {
-    2401: [replace_attack_def_with_just_def],  # Water Golem S1
-    2402: [replace_attack_def_with_just_def],  # Fire Golem S1
-    2403: [replace_attack_def_with_just_def],  # Wind Golem S1
-    2404: [replace_attack_def_with_just_def],  # Light Golem S1
-    2405: [replace_attack_def_with_just_def],  # Dark Golem S1
-    2406: [replace_attack_def_with_just_def],  # Water Golem S2
-    2407: [replace_attack_def_with_just_def],  # Fire Golem S2
-    2410: [replace_attack_def_with_just_def],  # Dark Golem S2
+    2401: [replace_golem_multiplier],  # Water Golem S1
+    2402: [replace_golem_multiplier],  # Fire Golem S1
+    2403: [replace_golem_multiplier],  # Wind Golem S1
+    2404: [replace_golem_multiplier],  # Light Golem S1
+    2405: [replace_golem_multiplier],  # Dark Golem S1
+    2406: [replace_golem_multiplier],  # Water Golem S2
+    2407: [replace_golem_multiplier],  # Fire Golem S2
+    2410: [replace_golem_multiplier],  # Dark Golem S2
     2816: [remove_multiplier], # Water Sylphid S3
+    2901: [replace_attack_def_with_just_def],  # Water Dragon S1
     2909: [fix_holy_light_multiplier],  # Light Dragon S2
     4606: [remove_multiplier], # Water Howl (Unawakened) S2
     4607: [remove_multiplier], # Fire Howl (Unawakened) S2

--- a/herders/sync_parser.py
+++ b/herders/sync_parser.py
@@ -231,6 +231,9 @@ def _parse_changed_item_list(changed_item_list, summoner):
         # parse artifact craft drop - enchants
         elif item_type == GameItem.CATEGORY_ARTIFACT_CRAFT:
             _create_new_artifact_craft(info, summoner)
+        # parse HOH - monster pieces
+        elif item_type == GameItem.CATEGORY_MONSTER_PIECE:
+            _sync_monster_piece(info, summoner)
 
 
 def _parse_reward(reward, summoner):
@@ -286,8 +289,8 @@ def sync_rift_reward(summoner, log_data):
             # material storage
             if reward['type'] == GameItem.CATEGORY_CRAFT_STUFF:
                 _add_quantity_to_item(reward, summoner)
-            else:
-                # rune, grind, enchant
+            elif reward['type'] in [GameItem.CATEGORY_RUNE, GameItem.CATEGORY_RUNE_CRAFT, GameItem.CATEGORY_MONSTER]:
+                # rune, grind, enchant, rainbowmon
                 changed_item_list.append(reward)
 
         _parse_changed_item_list(changed_item_list, summoner)


### PR DESCRIPTION
* Fixed Verad multiplier during preprocessing game data files
* Added Monster Pieces sync from HOH dungeons in Live Sync
* Fixed Live Sync throwing errors during Live Sync, when one of the rewards is Scroll type