### PR TITLE
Filter Optimization & Image Lazy Loading

### DIFF
--- a/api/templates/api/monster_instance/popover.html
+++ b/api/templates/api/monster_instance/popover.html
@@ -77,7 +77,7 @@
         <td colspan="4" style="position:relative">
             {% for skill in instance.monster.skills %}
             <div class="monster-image" style="position:relative">
-                <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" class="monster-thumb" />
+                <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" class="monster-thumb" loading="lazy" />
                 {% if skill.max_level > 1 %}
                 <span class="image-plus image-plus-right">
                     {% if forloop.counter == 1 %}

--- a/api/templates/api/monster_skills/popover.html
+++ b/api/templates/api/monster_skills/popover.html
@@ -4,7 +4,7 @@
 <ul class="list-unstyled">
     <li>
         <div class="monster-skill-thumb pull-left">
-            <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" />
+            <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" loading="lazy" />
             <span class="image-plus image-plus-right">{{ skill.max_level }}</span>
         </div>
         <p>
@@ -32,7 +32,7 @@
         {% endif %}
         {% for effect in skill.skill_effect %}
             {% if effect.icon_filename %}
-                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect" />
+                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect" loading="lazy" />
             {% else %}
                 <span class="skill-effect {% if effect.is_buff %}skill-effect-buff{% else %}skill-effect-debuff{% endif %}">
                     <span>{{ effect.name }}</span>

--- a/api/templates/api/rune_instance/popover.html
+++ b/api/templates/api/rune_instance/popover.html
@@ -21,7 +21,7 @@
         {% endif %}
         {% if rune.value %}
             <li class="mana-crystals">
-                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" /> {{ rune.value }}
+                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" loading="lazy" /> {{ rune.value }}
                 {% if rune.marked_for_sale %}<span class="glyphicon glyphicon-piggy-bank" data-toggle="tooltip" data-placement="top" title="Marked for Sale"></span>{% endif %}
             </li>
         {% endif %}

--- a/api/templates/api/rune_instance/thumbnail.html
+++ b/api/templates/api/rune_instance/thumbnail.html
@@ -12,9 +12,9 @@
             </div>
             {% for x in rune.stars|get_range %}
                 {% if rune.level == 15 %}
-                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" />
+                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" loading="lazy" />
                 {% else %}
-                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
                 {% endif %}
             {% endfor %}
             <span class="image-plus image-plus-right">+{{ rune.level }}</span>

--- a/bestiary/filters.py
+++ b/bestiary/filters.py
@@ -53,7 +53,6 @@ class MonsterFilter(django_filters.FilterSet):
             return queryset
 
     def filter_skill_effects(self, queryset, name, value):
-        print(self.form.cleaned_data)
         old_filtering = self.form.cleaned_data.get('effects_logic', False)
         stat_scaling = self.form.cleaned_data.get('skills__scaling_stats__pk', [])
         passive = self.form.cleaned_data.get('skills__passive', None)

--- a/bestiary/filters.py
+++ b/bestiary/filters.py
@@ -13,6 +13,7 @@ class MonsterFilter(django_filters.FilterSet):
     leader_skill__area = django_filters.MultipleChoiceFilter(choices=LeaderSkill.AREA_CHOICES)
     skills__scaling_stats__pk = django_filters.ModelMultipleChoiceFilter(queryset=ScalingStat.objects.all(), to_field_name='pk', conjoined=True)
     skills__cooltime = django_filters.CharFilter(method='filter_bypass')
+    skills__hits = django_filters.CharFilter(method='filter_bypass')
     effects_logic = django_filters.BooleanFilter(method='filter_bypass')
     skills__skill_effect__pk = django_filters.ModelMultipleChoiceFilter(queryset=SkillEffect.objects.all(), method='filter_skill_effects')
     skills__passive = django_filters.BooleanFilter(method='filter_bypass')
@@ -34,8 +35,6 @@ class MonsterFilter(django_filters.FilterSet):
             'leader_skill__area': ['exact'],
             'skills__skill_effect__pk': ['exact'],
             'skills__scaling_stats__pk': ['exact'],
-            'skills__cooltime': ['lte', 'gte'],
-            'skills__hits': ['lte', 'gte'],
             'skills__passive': ['exact'],
             'skills__aoe': ['exact'],
             'effects_logic': ['exact'],
@@ -54,21 +53,27 @@ class MonsterFilter(django_filters.FilterSet):
             return queryset
 
     def filter_skill_effects(self, queryset, name, value):
+        print(self.form.cleaned_data)
         old_filtering = self.form.cleaned_data.get('effects_logic', False)
         stat_scaling = self.form.cleaned_data.get('skills__scaling_stats__pk', [])
-        cooltimes = self.form.cleaned_data.get('skills__cooltime', '')
-        max_num_hits = self.form.cleaned_data.get('skills__hits__lte', 99)
-        min_num_hits = self.form.cleaned_data.get('skills__hits__gte', 0)
         passive = self.form.cleaned_data.get('skills__passive', None)
         aoe = self.form.cleaned_data.get('skills__aoe', None)
 
         try:
-            cooltimes = cooltimes.split(',')
-            min_cooltime = int(cooltimes[0])
-            max_cooltime = int(cooltimes[1])
+            [min_cooltime, max_cooltime] = self.form.cleaned_data['skills__cooltime'].split(',')
+            min_cooltime = int(min_cooltime)
+            max_cooltime = int(max_cooltime)
         except:
-            min_cooltime = 0
-            max_cooltime = 999
+            min_cooltime = None
+            max_cooltime = None
+
+        try:
+            [min_num_hits, max_num_hits] = self.form.cleaned_data['skills__hits'].split(',')
+            min_num_hits = int(min_num_hits)
+            max_num_hits = int(max_num_hits)
+        except:
+            min_num_hits = None
+            max_num_hits = None
 
         if old_filtering:
             # Filter if any skill on the monster has the designated fields
@@ -78,15 +83,25 @@ class MonsterFilter(django_filters.FilterSet):
             for pk in stat_scaling:
                 queryset = queryset.filter(skills__scaling_stats=pk)
 
-            cooltime_filter = Q(skills__cooltime__gte=min_cooltime) & Q(skills__cooltime__lte=max_cooltime)
-            if min_cooltime == 0 or max_cooltime == 0:
-                cooltime_filter = Q(skills__cooltime__isnull=True) | cooltime_filter
+            cooltime_filter = Q()
+            
+            if max_cooltime is not None and max_cooltime > 0:
+                cooltime_filter &= Q(skills__cooltime__lte=max_cooltime)
+            
+            if min_cooltime is not None and min_cooltime > 0:
+                cooltime_filter &= Q(skills__cooltime__gte=min_cooltime)
 
-            queryset = queryset.filter(
-                cooltime_filter,
-                skills__hits__lte=max_num_hits,
-                skills__hits__gte=min_num_hits,
-            )
+            if min_cooltime == 0 or max_cooltime == 0:
+                cooltime_filter |= Q(skills__cooltime__isnull=True)
+
+            if cooltime_filter:
+                queryset = queryset.filter(cooltime_filter)
+
+            if max_num_hits:
+                queryset = queryset.filter(skills__hits__lte=max_num_hits)
+
+            if min_num_hits:
+                queryset = queryset.filter(skills__hits__gte=min_num_hits)
 
             if passive is not None:
                 queryset = queryset.filter(skills__passive=passive)
@@ -100,6 +115,7 @@ class MonsterFilter(django_filters.FilterSet):
             # Filter effects based on effects of each individual skill. This ensures a monster will not show up unless it has
             # the desired effects on the same skill rather than across any skills.
             skills = Skill.objects.all()
+            skills_count = skills.count()
 
             for effect in value:
                 skills = skills.filter(skill_effect=effect)
@@ -107,21 +123,40 @@ class MonsterFilter(django_filters.FilterSet):
             for pk in stat_scaling:
                 skills = skills.filter(scaling_stats=pk)
 
-            cooltime_filter = Q(cooltime__gte=min_cooltime) & Q(cooltime__lte=max_cooltime)
-            if min_cooltime == 0 or max_cooltime == 0:
-                cooltime_filter = Q(cooltime__isnull=True) | cooltime_filter
+            cooltime_filter = Q()
 
-            skills = skills.filter(
-                cooltime_filter,
-                hits__lte=max_num_hits,
-                hits__gte=min_num_hits,
-            )
+            if max_cooltime is not None and max_cooltime > 0:
+                cooltime_filter &= Q(cooltime__lte=max_cooltime)
+            
+            if min_cooltime is not None and min_cooltime > 0:
+                cooltime_filter &= Q(cooltime__gte=min_cooltime)
+
+            if min_cooltime == 0 or max_cooltime == 0:
+                cooltime_filter |= Q(cooltime__isnull=True)
+
+            if cooltime_filter:
+                skills = skills.filter(cooltime_filter)
+            
+            hits_filter = Q()
+
+            if max_num_hits:
+                hits_filter &= Q(hits__lte=max_num_hits)
+
+            if min_num_hits:
+                hits_filter &= Q(hits__gte=min_num_hits)
+
+            if hits_filter:
+                skills = skills.filter(hits_filter)
 
             if passive is not None:
                 skills = skills.filter(passive=passive)
 
             if aoe is not None:
                 skills = skills.filter(aoe=aoe)
+
+            # no skill filters
+            if skills_count == skills.count():
+                return queryset.distinct()
 
             return queryset.filter(skills__in=skills).distinct()
 

--- a/bestiary/forms.py
+++ b/bestiary/forms.py
@@ -264,28 +264,17 @@ class FilterMonsterForm(forms.Form):
 
     def clean(self):
         super(FilterMonsterForm, self).clean()
-
         # Coalesce the effect fields into a single one that the filter can understand
         selected_buff_effects = self.cleaned_data.get('buffs')
         selected_debuff_effects = self.cleaned_data.get('debuffs')
         selected_other_effects = self.cleaned_data.get('other_effects')
         self.cleaned_data['skills__skill_effect__pk'] = chain(selected_buff_effects, selected_debuff_effects, selected_other_effects)
 
-        # Split the slider ranges into two min/max fields for the filters
+        # Split the slider ranges into two min/max fields for the automatic filters
         try:
             [min_stars, max_stars] = self.cleaned_data['natural_stars'].split(',')
+            self.cleaned_data['natural_stars__gte'] = int(min_stars)
+            self.cleaned_data['natural_stars__lte'] = int(max_stars)
         except:
-            min_stars = 1
-            max_stars = 6
-
-        self.cleaned_data['natural_stars__gte'] = int(min_stars)
-        self.cleaned_data['natural_stars__lte'] = int(max_stars)
-
-        try:
-            [min_hits, max_hits] = self.cleaned_data['skills__hits'].split(',')
-        except:
-            min_hits = 0
-            max_hits = 7
-
-        self.cleaned_data['skills__hits__gte'] = int(min_hits)
-        self.cleaned_data['skills__hits__lte'] = int(max_hits)
+            self.cleaned_data['natural_stars__gte'] = None
+            self.cleaned_data['natural_stars__lte'] = None

--- a/bestiary/models/items.py
+++ b/bestiary/models/items.py
@@ -101,7 +101,7 @@ class GameItem(models.Model):
     def image_tag(self):
         if self.icon:
             path = static('herders/images/items/' + self.icon)
-            return mark_safe(f'<img src="{path}" height="42" width="42"/>')
+            return mark_safe(f'<img src="{path}" height="42" width="42" loading="lazy" />')
         else:
             return 'No Image'
 
@@ -188,7 +188,7 @@ class Building(models.Model, base.Elements):
 
     def image_url(self):
         if self.icon_filename:
-            return mark_safe('<img src="%s" height="42" width="42"/>' % static('herders/images/buildings/' + self.icon_filename))
+            return mark_safe('<img src="%s" height="42" width="42" loading="lazy" />' % static('herders/images/buildings/' + self.icon_filename))
         else:
             return 'No Image'
 
@@ -205,7 +205,7 @@ class Source(models.Model):
 
     def image_url(self):
         if self.icon_filename:
-            return mark_safe('<img src="%s" height="42" width="42"/>' % static('herders/images/icons/' + self.icon_filename))
+            return mark_safe('<img src="%s" height="42" width="42" loading="lazy" />' % static('herders/images/icons/' + self.icon_filename))
         else:
             return 'No Image'
 

--- a/bestiary/models/monsters.py
+++ b/bestiary/models/monsters.py
@@ -129,7 +129,7 @@ class Monster(models.Model, base.Elements, base.Stars, base.Archetype):
 
     def image_url(self):
         if self.image_filename:
-            return mark_safe('<img src="%s" height="42" width="42"/>' % static('herders/images/monsters/' + self.image_filename))
+            return mark_safe('<img src="%s" height="42" width="42" loading="lazy" />' % static('herders/images/monsters/' + self.image_filename))
         else:
             return 'No Image'
 

--- a/bestiary/models/skills.py
+++ b/bestiary/models/skills.py
@@ -29,7 +29,7 @@ class Skill(models.Model):
 
     def image_url(self):
         if self.icon_filename:
-            return mark_safe('<img src="%s" height="42" width="42"/>' % static('herders/images/skills/' + self.icon_filename))
+            return mark_safe('<img src="%s" height="42" width="42" loading="lazy" />' % static('herders/images/skills/' + self.icon_filename))
         else:
             return 'No Image'
 
@@ -202,7 +202,7 @@ class LeaderSkill(models.Model):
         return 'leader_skill_{0}{1}.png'.format(self.get_attribute_display().replace(' ', '_'), suffix)
 
     def image_url(self):
-        return mark_safe('<img src="{}" height="42" width="42"/>'.format(
+        return mark_safe('<img src="{}" height="42" width="42" loading="lazy" />'.format(
             static('herders/images/skills/leader/' + self.icon_filename())
         ))
 
@@ -257,7 +257,7 @@ class SkillEffect(models.Model):
 
     def image_url(self):
         if self.icon_filename:
-            return mark_safe('<img src="%s" height="42" width="42"/>' % static('herders/images/buffs/' + self.icon_filename))
+            return mark_safe('<img src="%s" height="42" width="42" loading="lazy" />' % static('herders/images/buffs/' + self.icon_filename))
         else:
             return 'No Image'
 

--- a/bestiary/static/bestiary/js/bestiary.js
+++ b/bestiary/static/bestiary/js/bestiary.js
@@ -33,19 +33,10 @@ function update_bestiary_form_with_query(){
 
 function clean_bestiary_url_data(data){
     var cleanedParams = clean_query_params(data)
-    // We only get multi slider values after using `clean_query_params` function
-    // Need to check if these values are equal min-max, if yes -> delete them from query
-    // Because there's no point in using Filter without any effect
     var params = new URLSearchParams(cleanedParams)
     var multiSliderParams = ['natural_stars', 'skills__cooltime', 'skills__hits']
-    for (let name of multiSliderParams) {
-        var [valueMin, valueMax] = params.get(name).split(',')
-        var el = $("input[name='" + name + "']")
-        if(el.attr("data-slider-min") === valueMin && el.attr("data-slider-max") === valueMax){
-            params.delete(name)    
-        }
-    }
-    return params.toString()
+    var newData = clean_multi_slider_min_max_params(params, multiSliderParams)
+    return newData
 }
 
 function update_inventory() {
@@ -124,15 +115,7 @@ $('body')
             url: $form.attr('action'),
             data: formData
         }).done(function (data) {
-            // Create URL with Filter fields
-            var params_start = this.url.lastIndexOf('/?')
-            if (params_start > -1){
-                var index_start = Math.min(params_start + 2, this.url.length - 1) // +2 because /? are 2 symbols
-                var params = clean_query_params(this.url.substring(index_start))
-                $("#idapply").remove() // Apply button adds something to data :/
-                history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + params)
-            }
-            //
+            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + formData)
 
             ToggleLoading($('body'), false);
             $('#bestiary-inventory').replaceWith(data);

--- a/bestiary/static/bestiary/js/bestiary.js
+++ b/bestiary/static/bestiary/js/bestiary.js
@@ -31,6 +31,23 @@ function update_bestiary_form_with_query(){
     update_form_toggle_from_query(params, 'effects_logic');
 }
 
+function clean_bestiary_url_data(data){
+    var cleanedParams = clean_query_params(data)
+    // We only get multi slider values after using `clean_query_params` function
+    // Need to check if these values are equal min-max, if yes -> delete them from query
+    // Because there's no point in using Filter without any effect
+    var params = new URLSearchParams(cleanedParams)
+    var multiSliderParams = ['natural_stars', 'skills__cooltime', 'skills__hits']
+    for (let name of multiSliderParams) {
+        var [valueMin, valueMax] = params.get(name).split(',')
+        var el = $("input[name='" + name + "']")
+        if(el.attr("data-slider-min") === valueMin && el.attr("data-slider-max") === valueMax){
+            params.delete(name)    
+        }
+    }
+    return params.toString()
+}
+
 function update_inventory() {
     $('#FilterBestiaryForm').submit();
 }
@@ -101,10 +118,11 @@ $('body')
         ToggleLoading($('body'), true);
 
         var $form = $(this);
+        var formData = clean_bestiary_url_data($form.serialize())
         $.ajax({
             type: $form.attr('method'),
             url: $form.attr('action'),
-            data: $form.serialize()
+            data: formData
         }).done(function (data) {
             // Create URL with Filter fields
             var params_start = this.url.lastIndexOf('/?')

--- a/bestiary/templates/bestiary/detail_base.html
+++ b/bestiary/templates/bestiary/detail_base.html
@@ -12,7 +12,7 @@
         {% for mon in family %}
             <li role="presentation" {% if mon.bestiary_slug == active_slug %}class="active"{% endif %}>
                 <a href="{% url 'bestiary:detail' monster_slug=mon.bestiary_slug %}" role="tab">
-                    <img class="monster-thumb" src="{{ img_url_prefix }}monsters/{{ mon.image_filename }}" /> {{ mon }} {% if mon.is_awakened %}({{ mon.get_element_display }}){% endif %}
+                    <img class="monster-thumb" src="{{ img_url_prefix }}monsters/{{ mon.image_filename }}" loading="lazy" /> {{ mon }} {% if mon.is_awakened %}({{ mon.get_element_display }}){% endif %}
                 </a>
             </li>
         {% endfor %}

--- a/bestiary/templates/bestiary/essence_fragment.html
+++ b/bestiary/templates/bestiary/essence_fragment.html
@@ -2,6 +2,6 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <div class="element-essence" data-toggle="tooltip" data-placement="top" data-container="body" title="{{ element|capfirst }} {{ size|capfirst }}">
-    <img src="{{ img_url_prefix }}items/essence_{{ element }}_{{ size }}.png" />
+    <img src="{{ img_url_prefix }}items/essence_{{ element }}_{{ size }}.png" loading="lazy" />
     {% if not count == None %}<span class="image-plus image-plus-right">{{ count }}</span>{% endif %}
 </div>

--- a/bestiary/templates/bestiary/inventory.html
+++ b/bestiary/templates/bestiary/inventory.html
@@ -76,28 +76,28 @@
                         <td><a href="{% url 'bestiary:detail' monster_slug=monster.bestiary_slug %}">{{ monster.name|title }}</a></td>
                         <td>{{ monster.base_stars }}<span class="glyphicon glyphicon-star"></span></td>
                         <td class="monster-element">
-                            <img src="{{ img_url_prefix }}elements/{{ monster.element }}.png" class="monster-element" />
+                            <img src="{{ img_url_prefix }}elements/{{ monster.element }}.png" class="monster-element" loading="lazy" />
                             <span class="hidden">{{ monster.element }}</span>
                         </td>
                         <td class="monster-type">{{ monster.get_archetype_display }}</td>
                         <td class="monster-awakens">
                             {% if monster.awakens_to %}
                             <a href="{% url 'bestiary:detail' monster_slug=monster.awakens_to.bestiary_slug %}">
-                                <img src="{{ img_url_prefix }}monsters/{{ monster.awakens_to.image_filename }}" class="monster-thumb"/> {{ monster.awakens_to.name|title }}
+                                <img src="{{ img_url_prefix }}monsters/{{ monster.awakens_to.image_filename }}" class="monster-thumb" loading="lazy" /> {{ monster.awakens_to.name|title }}
                             </a>
                             {% endif %}
                         </td>
                         <td class="monster-awakens">
                             {% if monster.awakens_from %}
                             <a href="{% url 'bestiary:detail' monster_slug=monster.awakens_from.bestiary_slug %}">
-                                <img src="{{ img_url_prefix }}monsters/{{ monster.awakens_from.image_filename }}" class="monster-thumb"/> {{ monster.awakens_from.name|title }}
+                                <img src="{{ img_url_prefix }}monsters/{{ monster.awakens_from.image_filename }}" class="monster-thumb" loading="lazy" /> {{ monster.awakens_from.name|title }}
                             </a>
                             {% endif %}
                         </td>
                         <td class="monster-leader-skill">
                             {% if monster.leader_skill %}
                                 <div>
-                                    <img src="{{ img_url_prefix }}skills/leader/{{ monster.leader_skill.icon_filename }}"
+                                    <img src="{{ img_url_prefix }}skills/leader/{{ monster.leader_skill.icon_filename }}" loading="lazy" 
                                          data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="Leader Skill" data-content="{{ monster.leader_skill.skill_string }}" />
                                     <span class="image-plus image-plus-top-left">{{ monster.leader_skill.amount }}%</span>
                                     <span class="hidden">
@@ -110,7 +110,7 @@
                         <td class="monster-awaken-materials">
                             {% for skill in monster.skills.all %}
                                 <div class="monster-skill-thumb pull-left skill-popover" data-skill-id="{{ skill.pk }}" title="{{ skill.name }}" data-placement="top">
-                                    <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" />
+                                    <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" loading="lazy" />
                                     {% if skill.max_level > 1 %}<span class="image-plus image-plus-right">{{ skill.max_level }}</span>{% endif %}
                                 </div>
                             {% endfor %}
@@ -118,7 +118,7 @@
                         <td>
                             {% if monster.skill_ups_to_max > 0 %}
                             <div class="monster-image">
-                                <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb" loading="lazy" />
                                 <span class="image-plus image-plus-main">{{ monster.skill_ups_to_max }}</span>
                             </div>
                             {% else %}

--- a/bestiary/templates/bestiary/monster/portrait_large.html
+++ b/bestiary/templates/bestiary/monster/portrait_large.html
@@ -2,11 +2,11 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <div class="monster-box-thumb">
-    <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" alt="{{ monster.name }} portrait"/>
+    <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" alt="{{ monster.name }} portrait" loading="lazy" />
     {% include './stars.html' %}
     <div class="image-plus-icon">
         {% if monster.fusion_food %}
-            <img src="{{ img_url_prefix }}icons/fusion.png" alt="fusion ingredient"/>
+            <img src="{{ img_url_prefix }}icons/fusion.png" alt="fusion ingredient" loading="lazy" />
         {% endif %}
     </div>
 </div>

--- a/bestiary/templates/bestiary/monster/portrait_small.html
+++ b/bestiary/templates/bestiary/monster/portrait_small.html
@@ -2,6 +2,6 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <div class="monster-image">
-    <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" class="monster-thumb" alt="{{ monster.name }} portrait" />
+    <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" class="monster-thumb" alt="{{ monster.name }} portrait" loading="lazy" />
     {% include './stars.html' %}
 </div>

--- a/bestiary/templates/bestiary/monster/stars.html
+++ b/bestiary/templates/bestiary/monster/stars.html
@@ -5,17 +5,17 @@
     {% for x in monster.base_stars|get_range %}
         {% if monster.can_awaken %}
             {% if monster.awaken_level == monster.AWAKEN_LEVEL_AWAKENED %}
-                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% elif monster.awaken_level == monster.AWAKEN_LEVEL_SECOND %}
-                <img src="{{ img_url_prefix }}stars/star-awakened2.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-awakened2.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% else %}
-                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% endif %}
         {% else %}
             {% if monster.awaken_level == monster.AWAKEN_LEVEL_INCOMPLETE %}
-                <img src="{{ img_url_prefix }}stars/star-incomplete.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-incomplete.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% else %}
-                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/bestiary/templates/bestiary/monster_info.html
+++ b/bestiary/templates/bestiary/monster_info.html
@@ -4,7 +4,7 @@
 
 <div class="panel panel-default">
     <div class="panel-heading">
-        <span class="panel-title"><strong><img src="{{ img_url_prefix }}elements/{{ monster.element }}.png" style="height:1em"/> {{ monster.name }}</strong> - <small>{{ monster.get_archetype_display }}</small></span>
+        <span class="panel-title"><strong><img src="{{ img_url_prefix }}elements/{{ monster.element }}.png" style="height:1em" loading="lazy" /> {{ monster.name }}</strong> - <small>{{ monster.get_archetype_display }}</small></span>
         {% if request.user.is_superuser %}
             <a href="{% url 'admin:bestiary_monster_change' object_id=monster.pk %}" class="btn btn-xs edit-skill pull-right" target="_blank"><span class="glyphicon glyphicon-pencil"></span></a>
         {% endif %}
@@ -42,7 +42,7 @@
                     <td class="monster-sources">
                         {% for source in sources %}
                             {% if source.icon_filename %}
-                            <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}"
+                            <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}" loading="lazy" 
                                  class="monster-source" data-toggle="tooltip" data-placement="top" data-container="body" title="{{ source.name }}" />
                             {% else %}
                             <span class="monster-source"><span>{{ source }}</span></span>
@@ -93,7 +93,7 @@
                     <td>Skill-ups to Max</td>
                     <td class="monster-awaken-materials">
                         <div class="monster-image">
-                            <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb"/>
+                            <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb" loading="lazy" />
                             <span class="image-plus image-plus-main">{{ monster.skill_ups_to_max }}</span>
                         </div>
                     </td>

--- a/bestiary/templates/bestiary/skills.html
+++ b/bestiary/templates/bestiary/skills.html
@@ -6,7 +6,7 @@
     <div class="col-lg-12">
         <div class="panel panel-default">
             <div class="panel-body">
-                <div class="monster-skill-thumb pull-left"><img src="{{ img_url_prefix }}skills/leader/{{ monster.leader_skill.icon_filename }}" /></div>
+                <div class="monster-skill-thumb pull-left"><img src="{{ img_url_prefix }}skills/leader/{{ monster.leader_skill.icon_filename }}" loading="lazy" /></div>
                 <h4 class="list-group-item-heading">Leader Skill</h4>
                 <div class="list-group-item-text">
                     {{ monster.leader_skill.skill_string }}
@@ -29,7 +29,7 @@
             <ul class="list-group">
                 <li class="list-group-item">
                     <div class="monster-skill-thumb pull-left">
-                        <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" />
+                        <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" loading="lazy" />
                         <span class="image-plus image-plus-right">{{ skill.max_level }}</span>
                     </div>
                     <p>
@@ -61,7 +61,7 @@
                     {% endif %}
                     {% for effect in skill.skill_effect.all %}
                         {% if effect.icon_filename %}
-                        <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect pull-left"
+                        <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect pull-left" loading="lazy" 
                                 data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}"
                                 />
                         {% else %}

--- a/bestiary/templates/dungeons/base.html
+++ b/bestiary/templates/dungeons/base.html
@@ -26,7 +26,7 @@
                     <div class="media-left">
                         {% if d.icon %}
                             <a href="{% url 'bestiary:dungeon_detail_no_floor' slug=d.slug %}">
-                                <img src="{{ img_url_prefix }}dungeons/{{ d.icon }}" alt="{{ d.name }} icon" class="media-object dungeon-icon">
+                                <img src="{{ img_url_prefix }}dungeons/{{ d.icon }}" alt="{{ d.name }} icon" class="media-object dungeon-icon" loading="lazy" />
                             </a>
                         {% endif %}
                     </div>

--- a/bestiary/templates/dungeons/detail/report_by_grade_summary_table.html
+++ b/bestiary/templates/dungeons/detail/report_by_grade_summary_table.html
@@ -12,7 +12,7 @@
                 {% for drop in table.0.drops %}
                     <th>
                         {% if drop.icon %}
-                        <img src="{{ img_url_prefix }}{{ drop.type }}s/{{ drop.icon }}" alt="{{ drop.name }} icon" class="monster-inline"/>
+                        <img src="{{ img_url_prefix }}{{ drop.type }}s/{{ drop.icon }}" alt="{{ drop.name }} icon" class="monster-inline" loading="lazy" />
                         {% endif %}
                         {{ drop.name }}
                     </th>

--- a/data_log/templates/data_log/drops/item.html
+++ b/data_log/templates/data_log/drops/item.html
@@ -3,7 +3,7 @@
 
 <div class="media">
     <div class="media-left">
-        <img class="media-object monster-thumb" src="{{ img_url_prefix }}items/{{ item.icon }}" alt="{{ item.name }}">
+        <img class="media-object monster-thumb" src="{{ img_url_prefix }}items/{{ item.icon }}" alt="{{ item.name }}" loading="lazy" >
     </div>
     <div class="media-body">
         <h4 class="media-heading">{{ item.name }}</h4>

--- a/data_log/templates/data_log/reports/summon.html
+++ b/data_log/templates/data_log/reports/summon.html
@@ -31,7 +31,7 @@
                     <div class="list-group">
                         {% for item in item_list %}
                             <a href="{% url 'data_log:summon_detail' slug=item.slug %}" class="list-group-item">
-                                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="image-inline" alt="{{ item.name }} icon" />
+                                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="image-inline" alt="{{ item.name }} icon" loading="lazy" />
                                 {{ item }}
                             </a>
                         {% endfor %}

--- a/data_log/templates/data_log/summary_items.html
+++ b/data_log/templates/data_log/summary_items.html
@@ -5,7 +5,7 @@
     {% for item in items %}
         <tr>
             <td class="monster-info-icons-column">
-                <img class="media-object monster-thumb" src="{{ img_url_prefix }}items/{{ item.icon }}" alt="{{ item.name }}">
+                <img class="media-object monster-thumb" src="{{ img_url_prefix }}items/{{ item.icon }}" alt="{{ item.name }}" loading="lazy" >
             </td>
             <td>
                 {{ item.name }}

--- a/data_log/templates/data_log/summary_monsters.html
+++ b/data_log/templates/data_log/summary_monsters.html
@@ -7,15 +7,15 @@
             <td class="monster-info-icons-column">
                 <div class="monster-image">
                     <a href="{% url 'bestiary:detail' monster_slug=monster.slug %}">
-                        <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb" loading="lazy" />
                         <span>
                             {% for x in monster.stars|get_range %}
                                 {% if monster.is_awakened %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% elif monster.can_awaken %}
-                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% else %}
-                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endif %}
                             {% endfor %}
                         </span>

--- a/data_log/templates/data_log/summary_runes.html
+++ b/data_log/templates/data_log/summary_runes.html
@@ -10,7 +10,7 @@
                     <p class="list-group-item-text">
                         {% for set in runes.sets %}
                             <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ set.type }}">
-                                <img src="{{ img_url_prefix }}runes/{{ set.type|lower }}.png" alt="{{ set.type }}" class="monster-thumb" />
+                                <img src="{{ img_url_prefix }}runes/{{ set.type|lower }}.png" alt="{{ set.type }}" class="monster-thumb" loading="lazy" />
                             </div>
                         {% endfor %}
                     </p>

--- a/data_log/templates/data_log/summary_secret_dungeons.html
+++ b/data_log/templates/data_log/summary_secret_dungeons.html
@@ -7,15 +7,15 @@
             <td class="monster-info-icons-column">
                 <div class="monster-image">
                     <a href="{% url 'bestiary:detail' monster_slug=monster.slug %}">
-                        <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb" loading="lazy" />
                         <span>
                             {% for x in monster.stars|get_range %}
                                 {% if monster.is_awakened %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% elif monster.can_awaken %}
-                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% else %}
-                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endif %}
                             {% endfor %}
                         </span>

--- a/herders/forms.py
+++ b/herders/forms.py
@@ -717,42 +717,30 @@ class FilterMonsterInstanceForm(forms.Form):
         self.cleaned_data['in_storage'] = choices.get(self.cleaned_data.get('in_storage', 'None'), None)
         self.cleaned_data['monster__fusion_food'] = choices.get(self.cleaned_data.get('monster__fusion_food', 'None'), None)
 
-        # Split the slider ranges into two min/max fields for the filters
+        # Split the slider ranges into two min/max fields for the automatic filters
         try:
             [min_lv, max_lv] = self.cleaned_data['level'].split(',')
+            self.cleaned_data['level__gte'] = int(min_lv)
+            self.cleaned_data['level__lte'] = int(max_lv)
         except:
-            min_lv = 1
-            max_lv = 40
-
-        self.cleaned_data['level__gte'] = int(min_lv)
-        self.cleaned_data['level__lte'] = int(max_lv)
+            self.cleaned_data['level__gte'] = None
+            self.cleaned_data['level__lte'] = None
 
         try:
             [min_stars, max_stars] = self.cleaned_data['stars'].split(',')
+            self.cleaned_data['stars__gte'] = int(min_stars)
+            self.cleaned_data['stars__lte'] = int(max_stars)
         except:
-            min_stars = 1
-            max_stars = 6
-
-        self.cleaned_data['stars__gte'] = int(min_stars)
-        self.cleaned_data['stars__lte'] = int(max_stars)
+            self.cleaned_data['stars__gte'] = None
+            self.cleaned_data['stars__lte'] = None
 
         try:
             [min_nat_stars, max_nat_stars] = self.cleaned_data['monster__natural_stars'].split(',')
+            self.cleaned_data['monster__natural_stars__gte'] = int(min_nat_stars)
+            self.cleaned_data['monster__natural_stars__lte'] = int(max_nat_stars)
         except:
-            min_nat_stars = 1
-            max_nat_stars = 5
-
-        self.cleaned_data['monster__natural_stars__gte'] = int(min_nat_stars)
-        self.cleaned_data['monster__natural_stars__lte'] = int(max_nat_stars)
-
-        try:
-            [min_hits, max_hits] = self.cleaned_data['monster__skills__hits'].split(',')
-        except:
-            min_hits = 0
-            max_hits = 7
-
-        self.cleaned_data['monster__skills__hits__gte'] = int(min_hits)
-        self.cleaned_data['monster__skills__hits__lte'] = int(max_hits)
+            self.cleaned_data['monster__natural_stars__gte'] = None
+            self.cleaned_data['monster__natural_stars__lte'] = None
 
 
 # MonsterPiece forms

--- a/herders/management/commands/propagate_test_data.py
+++ b/herders/management/commands/propagate_test_data.py
@@ -1,0 +1,153 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.conf import settings
+from django.contrib.auth.models import User
+
+from herders.models import ArtifactInstance, RuneInstance, MonsterInstance, Summoner
+
+import os
+import json
+import copy
+import time
+import random
+import string
+
+class Command(BaseCommand):
+    help = 'Creates `accounts_quantity` accounts with propagated data from first Summoner.'
+    MIN, MAX = 1, 1000000000
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument(
+            '-a',
+            '--accounts_quantity',
+            type=int,
+            default=100,
+            help='Number of accounts to create',
+        )
+
+    def _rand(self, target, iter_target):
+        rand = random.randint(self.MIN, self.MAX)
+        while rand in target or rand in iter_target:
+            rand = random.randint(self.MIN, self.MAX)
+        return rand
+
+    def handle(self, *args, **kwargs):
+        # TODO: Add whole `herders` copy, not only Monsters, Runes & Artifacts
+        if not settings.DEBUG:
+            self.stdout.write(self.style.ERROR('Command used outside DEBUG Mode'))
+            return
+
+        # timestamp, so there's no problem with dupe account logins
+        ACC_LOGIN = f'propagated_$ID$_{int(time.time())}'
+        # some sort of PASSWD generator, we won't use it anyway
+        PASSWD = ''.join(random.choice(string.ascii_letters + string.digits + string.punctuation) for _ in range(24))
+
+        monster_fields = [
+            'pk', 'owner_id', 'monster_id', 'com2us_id', 'created', 'stars', 'level', 'skill_1_level', 'skill_2_level', 'skill_3_level', 'skill_4_level',
+            'fodder', 'in_storage', 'ignore_for_fusion', 'priority', 'notes', 'custom_name',
+            'rune_hp', 'rune_attack', 'rune_defense', 'rune_speed', 'rune_crit_rate', 'rune_crit_damage', 'rune_resistance', 'rune_accuracy',
+            'avg_rune_efficiency', 'artifact_hp', 'artifact_attack', 'artifact_defense',
+        ]
+        rune_fields = [
+            'type', 'owner_id', 'com2us_id', 'assigned_to_id', 'marked_for_sale', 'notes', 'main_stat', 'main_stat_value',
+            'substat_1', 'substat_1_value', 'substat_1_craft', 'substat_2', 'substat_2_value', 'substat_2_craft',
+            'substat_3', 'substat_3_value', 'substat_3_craft', 'substat_4', 'substat_4_value', 'substat_4_craft',
+            'innate_stat', 'innate_stat_value', 'stars', 'level', 'slot', 'quality', 'original_quality', 'ancient', 'value', 
+            'substats', 'substat_values', 'substats_enchanted', 'substats_grind_value', 'has_hp', 'has_atk', 'has_def',
+            'has_crit_rate', 'has_crit_dmg', 'has_speed', 'has_resist', 'has_accuracy', 'efficiency', 'max_efficiency',
+            'substat_upgrades_remaining', 'has_grind', 'has_gem',
+        ]
+        artifact_fields = [
+            'owner_id', 'com2us_id', 'assigned_to_id', 'level', 'original_quality', 'main_stat', 'main_stat_value',
+            'effects', 'effects_value', 'effects_upgrade_count', 'effects_reroll_count', 'efficiency', 'max_efficiency',
+            'slot', 'element', 'archetype', 'quality'
+        ]
+
+        start = time.time()
+        acc_quantity = kwargs['accounts_quantity']
+        self.stdout.write(self.style.SUCCESS(f'Starting data duplication process for {acc_quantity} account(s)!'))
+
+        summoner = Summoner.objects.first()
+        if not summoner:
+            self.stdout.write(self.style.ERROR("No Summoner records in database, can't duplicate empty data"))
+            return
+
+        monsters = MonsterInstance.objects.filter(owner=summoner).values(*monster_fields)
+        runes = RuneInstance.objects.filter(owner=summoner).values(*rune_fields)
+        artifacts = ArtifactInstance.objects.filter(owner=summoner).values(*artifact_fields)
+
+        self.stdout.write(self.style.SUCCESS(f'Duplicating per account:'))
+        self.stdout.write(self.style.WARNING(f'- Monsters: {len(monsters)}'))
+        self.stdout.write(self.style.WARNING(f'- Runes: {len(runes)}'))
+        self.stdout.write(self.style.WARNING(f'- Artifacts: {len(artifacts)}'))
+
+        ids = {
+            'wizards': [summoner.com2us_id],
+            'monsters': list(set(MonsterInstance.objects.all().values_list('com2us_id', flat=True))),
+            'runes': list(set(RuneInstance.objects.all().values_list('com2us_id', flat=True))),
+            'artifacts': list(set(ArtifactInstance.objects.all().values_list('com2us_id', flat=True))),
+        }
+        monster_pks = {m.pop('pk'): m['com2us_id'] for m in monsters}
+
+        for iter in range(acc_quantity):
+            iter_ids = {
+                'monsters': {},
+                'runes': {},
+                'artifacts': {},
+            }
+            iter_objs = {
+                'monsters': [],
+                'runes': [],
+                'artifacts': [],
+            }
+            login = ACC_LOGIN.replace('$ID$', str(iter))
+            iter_start = time.time()
+            with transaction.atomic():
+                user = User.objects.create_user(login, login + '@gmail.com', PASSWD)
+
+                wizard_id = self._rand(ids['wizards'], [])
+                ids['wizards'].append(wizard_id)
+                summoner = Summoner.objects.create(user=user, com2us_id=wizard_id)
+
+                for mon in monsters:
+                    mon_obj = MonsterInstance(**mon)
+                    mon_id = self._rand(ids['monsters'], iter_ids['monsters'].values())
+                    iter_ids['monsters'][mon_obj.com2us_id] = mon_id
+                    mon_obj.com2us_id = mon_id
+                    mon_obj.owner = summoner
+                    iter_objs['monsters'].append(mon_obj)
+
+                iter_mons = {m.com2us_id: m for m in MonsterInstance.objects.bulk_create(iter_objs['monsters'])}
+
+                for rune in runes:
+                    rune_obj = RuneInstance(**rune)
+                    rune_id = self._rand(ids['runes'], iter_ids['runes'].values())
+                    iter_ids['runes'][rune_obj.com2us_id] = rune_id
+                    rune_obj.com2us_id = rune_id
+                    rune_obj.owner = summoner
+                    rune_obj.assigned_to = iter_mons[iter_ids['monsters'][monster_pks[rune['assigned_to_id']]]] if rune['assigned_to_id'] else None
+                    iter_objs['runes'].append(rune_obj)
+
+                for artifact in artifacts:
+                    artifact_obj = ArtifactInstance(**artifact)
+                    artifact_id = self._rand(ids['artifacts'], iter_ids['artifacts'].values())
+                    iter_ids['artifacts'][artifact_obj.com2us_id] = artifact_id
+                    artifact_obj.com2us_id = artifact_id
+                    artifact_obj.owner = summoner
+                    artifact_obj.assigned_to = iter_mons[iter_ids['monsters'][monster_pks[artifact['assigned_to_id']]]] if artifact['assigned_to_id'] else None
+                    iter_objs['artifacts'].append(artifact_obj)
+
+                RuneInstance.objects.bulk_create(iter_objs['runes'])
+                ArtifactInstance.objects.bulk_create(iter_objs['artifacts'])
+
+                for k, v in ids.items():
+                    if k not in iter_ids.keys():
+                        continue
+                    v += iter_ids[k].values()
+                    if len(v) != len(set(v)):
+                        raise ValueError(f"Some duplicates in {k}.")
+                
+                self.stdout.write(self.style.WARNING(f"[{iter + 1}] This iteration took {round(time.time() - iter_start, 2)} seconds ({round(time.time() - start, 2)} in total)!"))
+                
+        self.stdout.write(self.style.SUCCESS('Done creating accounts and duplicating data.'))

--- a/herders/static/herders/js/artifacts.js
+++ b/herders/static/herders/js/artifacts.js
@@ -19,6 +19,14 @@ function update_artifact_form_with_query(){
     update_form_toggle_from_query(params, 'effects_logic');
 }
 
+function clean_artifact_url_data(data){
+    var cleanedParams = clean_query_params(data)
+    var params = new URLSearchParams(cleanedParams)
+    var multiSliderParams = ['level']
+    var newData = clean_multi_slider_min_max_params(params, multiSliderParams)
+    return newData
+}
+
 function update_artifact_inventory() {
     $('#FilterInventoryForm').submit();
 }
@@ -123,20 +131,13 @@ $('body')
         ToggleLoading($('body'), true);
 
         var $form = $(this);
+        var formData = clean_artifact_url_data($form.serialize())
         $.ajax({
             type: $form.attr('method'),
             url: $form.attr('action'),
-            data: $form.serialize()
+            data: formData
         }).done(function (data) {
-            // Create URL with Filter fields
-            var params_start = this.url.lastIndexOf('/?')
-            if (params_start > -1){
-                var index_start = Math.min(params_start + 2, this.url.length - 1) // +2 because /? are 2 symbols
-                var params = clean_query_params(this.url.substring(index_start))
-                $("#idapply").remove() // Apply button adds something to data :/
-                history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + params)
-            }
-            //
+            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + formData)
 
             ToggleLoading($('body'), false);
             $('#rune-inventory').replaceWith(data);

--- a/herders/static/herders/js/custom.js
+++ b/herders/static/herders/js/custom.js
@@ -31,7 +31,7 @@ $.fn.editable.defaults.container = 'body';
 function iconSelect2Template(option) {
     if (option.id) {
         var resource_url = $(option.element).data('image');
-        return $('<span><img src="' + resource_url + '" /> ' + option.text + '</span>');
+        return $('<span><img src="' + resource_url + '" loading="lazy" /> ' + option.text + '</span>');
     }
     else {
         return option.text;

--- a/herders/static/herders/js/profile.js
+++ b/herders/static/herders/js/profile.js
@@ -350,7 +350,7 @@ $('body')
             url: $form.attr('action'),
             data: formData
         }).done(function (data) {
-            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + formData)
+            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/monster/inventory/')) + '/?' + formData)
 
             ToggleLoading($('body'), false);
             $('#monster-inventory').replaceWith(data);
@@ -409,8 +409,8 @@ $('body')
         });
 
         // Toggle button
-        $("input[name='effects_logic']").prop("checked", true);
-        $("input[name='effects_logic']").parent().removeClass('off');
+        $("input[name='effects_logic']").prop("checked", false);
+        $("input[name='effects_logic']").parent().addClass('off');
         
         update_monster_inventory();
     });

--- a/herders/static/herders/js/profile.js
+++ b/herders/static/herders/js/profile.js
@@ -37,6 +37,14 @@ function update_monster_form_with_query(){
     update_form_toggle_from_query(params, 'effects_logic');
 }
 
+function clean_monster_url_data(data){
+    var cleanedParams = clean_query_params(data)
+    var params = new URLSearchParams(cleanedParams)
+    var multiSliderParams = ['stars', 'monster__natural_stars', 'level', 'monster__skills__cooltime', 'monster__skills__hits']
+    var newData = clean_multi_slider_min_max_params(params, multiSliderParams)
+    return newData
+}
+
 function update_monster_inventory() {
     $('#FilterInventoryForm').submit();
 }
@@ -336,21 +344,13 @@ $('body')
         ToggleLoading($('body'), true);
 
         var $form = $(this);
-
+        var formData = clean_monster_url_data($form.serialize())
         $.ajax({
             type: $form.attr('method'),
             url: $form.attr('action'),
-            data: $form.serialize()
+            data: formData
         }).done(function (data) {
-            // Create URL with Filter fields
-            var params_start = this.url.lastIndexOf('/?')
-            if (params_start > -1){
-                var index_start = Math.min(params_start + 2, this.url.length - 1) // +2 because /? are 2 symbols
-                var params = clean_query_params(this.url.substring(index_start))
-                $("#idapply").remove() // Apply button adds something to data :/
-                history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/monster/inventory/')) + '/?' + params)
-            }
-            //
+            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + formData)
 
             ToggleLoading($('body'), false);
             $('#monster-inventory').replaceWith(data);

--- a/herders/static/herders/js/runes.js
+++ b/herders/static/herders/js/runes.js
@@ -33,6 +33,14 @@ function update_rune_form_with_query(){
     update_form_toggle_from_query(params, 'substat_reverse');
 }
 
+function clean_rune_url_data(data){
+    var cleanedParams = clean_query_params(data)
+    var params = new URLSearchParams(cleanedParams)
+    var multiSliderParams = ['stars', 'has_grind', 'level']
+    var newData = clean_multi_slider_min_max_params(params, multiSliderParams)
+    return newData
+}
+
 function update_rune_inventory() {
     $('#FilterInventoryForm').submit();
 }
@@ -346,20 +354,13 @@ $('body')
         ToggleLoading($('body'), true);
 
         var $form = $(this);
+        var formData = clean_rune_url_data($form.serialize())
         $.ajax({
             type: $form.attr('method'),
             url: $form.attr('action'),
-            data: $form.serialize()
+            data: formData
         }).done(function (data) {
-            // Create URL with Filter fields
-            var params_start = this.url.lastIndexOf('/?')
-            if (params_start > -1){
-                var index_start = Math.min(params_start + 2, this.url.length - 1) // +2 because /? are 2 symbols
-                var params = clean_query_params(this.url.substring(index_start))
-                $("#idapply").remove() // Apply button adds something to data :/
-                history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + params)
-            }
-            //
+            history.replaceState({}, "", this.url.substring(0, this.url.indexOf('/inventory/')) + '/?' + formData)
 
             ToggleLoading($('body'), false);
             $('#rune-inventory').replaceWith(data);

--- a/herders/templates/herders/monster_icon_button.html
+++ b/herders/templates/herders/monster_icon_button.html
@@ -3,15 +3,15 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <button class="btn btn-link monster-image {{ extra_classes }}" data-monster-id="{{ monster_id }}" data-stars="{{ stars }}" data-level="{{ level }}">
-    <img src="{{ img_url_prefix }}monsters/{{ filename }}" class="monster-thumb"/>
+    <img src="{{ img_url_prefix }}monsters/{{ filename }}" class="monster-thumb" loading="lazy" />
     <span>
         {% for x in stars|get_range %}
             {% if awakened %}
-                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
             {% elif can_awaken %}
-                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
             {% else %}
-                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
             {% endif %}
         {% endfor %}
     </span>

--- a/herders/templates/herders/profile/artifacts/artifact_panel_fragment.html
+++ b/herders/templates/herders/profile/artifacts/artifact_panel_fragment.html
@@ -35,15 +35,15 @@
             <div class="rune-assigned-to">
                 <div class="monster-image">
                     <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=artifact.assigned_to.pk.hex %}" target="_blank">
-                        <img src="{{ img_url_prefix }}monsters/{{ artifact.assigned_to.monster.image_filename }}" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/{{ artifact.assigned_to.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                         <span>
                             {% for x in artifact.assigned_to.stars|get_range %}
                                 {% if artifact.assigned_to.monster.is_awakened %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% elif artifact.assigned_to.monster.can_awaken %}
-                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% else %}
-                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endif %}
                             {% endfor %}
                         </span>

--- a/herders/templates/herders/profile/base.html
+++ b/herders/templates/herders/profile/base.html
@@ -32,25 +32,25 @@
         <ul class="nav navmenu-nav">
             <li {% if view == 'profile' %}class="dropdown open"{% endif %}>
                  <a href="{% url 'herders:profile_default' profile_name=profile_name %}">
-                    <img src="{% static 'herders/images/icons/monster.png' %}" /> Monsters
+                    <img src="{% static 'herders/images/icons/monster.png' %}" loading="lazy" /> Monsters
                 </a>
                 {% block monster_menu %}{% endblock monster_menu %}
             </li>
             <li {% if view == 'runes' and is_owner %}class="dropdown open"{% endif %}>
                 <a href="{% url 'herders:runes' profile_name=profile_name %}">
-                    <img src="{% static 'herders/images/icons/rune.png' %}" /> Runes
+                    <img src="{% static 'herders/images/icons/rune.png' %}" loading="lazy" /> Runes
                 </a>
                 {% block rune_menu %}{% endblock rune_menu %}
             </li>
             <li {% if view == 'artifacts' and is_owner %}class="dropdown open"{% endif %}>
                 <a href="{% url 'herders:artifacts' profile_name=profile_name %}">
-                    <img src="{% static 'herders/images/icons/artifact.png' %}" /> Artifacts
+                    <img src="{% static 'herders/images/icons/artifact.png' %}" loading="lazy" /> Artifacts
                 </a>
                 {% block artifact_menu %}{% endblock artifact_menu %}
             </li>
             <li {% if view == 'fusion' %}class="dropdown open"{% endif %}>
                 <a href="{% url 'herders:fusion' profile_name=profile_name %}">
-                    <img src="{% static 'herders/images/icons/fusion.png' %}" /> Fusion
+                    <img src="{% static 'herders/images/icons/fusion.png' %}" loading="lazy" /> Fusion
                 </a>
                 {% block fusion_menu %}{% endblock fusion_menu %}
             </li>

--- a/herders/templates/herders/profile/buildings/building_row_snippet.html
+++ b/herders/templates/herders/profile/buildings/building_row_snippet.html
@@ -2,16 +2,16 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <tr class="inventory-element" data-building-id="{{ bldg.base.pk }}">
-    <td class="monster-image"><img src="{{ img_url_prefix }}buildings/{{ bldg.base.icon_filename }}" class="monster-thumb"/></td>
+    <td class="monster-image"><img src="{{ img_url_prefix }}buildings/{{ bldg.base.icon_filename }}" class="monster-thumb" loading="lazy" /></td>
     <td>{{ bldg.base.name }} <span class="glyphicon glyphicon-question-sign" data-toggle="popover" data-container="body" data-trigger="hover" title="{{ bldg.base.name }}" data-content="{{ bldg.base.description }}"></span></td>
     <td>{% if bldg.instance %}{{ bldg.instance.level }}{% else %}0{% endif %}/{{ bldg.base.max_level }}</td>
     <td>{{ bldg.base.get_affected_stat_display }} +{{ bldg.stat_bonus }}{% if bldg.percent_stat %}%{% endif %}</td>
     <td>
         {{ bldg.base.get_area_display }}
-        {% if bldg.base.element %}(<img src="{{ img_url_prefix }}elements/{{ bldg.base.element }}.png" class="image-inline" /> only){% endif %}
+        {% if bldg.base.element %}(<img src="{{ img_url_prefix }}elements/{{ bldg.base.element }}.png" class="image-inline" loading="lazy" /> only){% endif %}
     </td>
     <td>
-        {{ bldg.spent_upgrade_cost }} / {{ bldg.total_upgrade_cost }}<img src="{{ img_url_prefix }}items/{{ bldg.currency }}" class="image-inline" />
+        {{ bldg.spent_upgrade_cost }} / {{ bldg.total_upgrade_cost }}<img src="{{ img_url_prefix }}items/{{ bldg.currency }}" class="image-inline" loading="lazy" />
     </td>
     {% if is_owner %}<td><button class="btn btn-xs btn-link edit-building" data-building-id="{{ bldg.base.pk }}"><span class="glyphicon glyphicon-pencil"></span></button></td>{% endif %}
 </tr>

--- a/herders/templates/herders/profile/buildings/inventory.html
+++ b/herders/templates/herders/profile/buildings/inventory.html
@@ -12,7 +12,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-sm-2">{{ spent_glory }} / {{ total_glory_cost }}<img src="{{ img_url_prefix }}items/glory_points.png" class="image-inline" /></div>
+            <div class="col-sm-2">{{ spent_glory }} / {{ total_glory_cost }}<img src="{{ img_url_prefix }}items/glory_points.png" class="image-inline" loading="lazy" /></div>
         </div>
         <div class="row">
             <div class="col-sm-2">Guild Points</div>
@@ -23,7 +23,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-sm-2">{{ spent_guild }} / {{ total_guild_cost }}<img src="{{ img_url_prefix }}items/guild_points.png" class="image-inline" /></div>
+            <div class="col-sm-2">{{ spent_guild }} / {{ total_guild_cost }}<img src="{{ img_url_prefix }}items/guild_points.png" class="image-inline" loading="lazy" /></div>
         </div>
     </div>
 </div>

--- a/herders/templates/herders/profile/data_logs/drops/artifact_popover.html
+++ b/herders/templates/herders/profile/data_logs/drops/artifact_popover.html
@@ -21,7 +21,7 @@
         {% endif %}
         {% if drop.value %}
             <li class="mana-crystals">
-                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" /> {{ drop.value }}
+                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" loading="lazy" /> {{ drop.value }}
             </li>
         {% endif %}
     </ul>

--- a/herders/templates/herders/profile/data_logs/drops/item_drops.html
+++ b/herders/templates/herders/profile/data_logs/drops/item_drops.html
@@ -3,7 +3,7 @@
 
 {% for drop in drops %}
 <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ drop.item.name }}">
-    <img src="{{ img_url_prefix }}items/{{ drop.item.icon }}" class="monster-thumb"/>
+    <img src="{{ img_url_prefix }}items/{{ drop.item.icon }}" class="monster-thumb" loading="lazy" />
     <span class="image-plus image-plus-right">{{ drop.quantity }}</span>
 </div>
 {% endfor %}

--- a/herders/templates/herders/profile/data_logs/drops/monster_drops.html
+++ b/herders/templates/herders/profile/data_logs/drops/monster_drops.html
@@ -5,15 +5,15 @@
 {% for drop in drops %}
 <a href="{% url 'bestiary:detail' monster_slug=drop.monster.bestiary_slug %}" class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ log.monster.get_element_display }} {{ drop.monster.name }}">
     <div>
-        <img src="{{ img_url_prefix }}monsters/{{ drop.monster.image_filename }}" class="monster-thumb"/>
+        <img src="{{ img_url_prefix }}monsters/{{ drop.monster.image_filename }}" class="monster-thumb" loading="lazy" />
         <span>
             {% for x in drop.grade|get_range %}
                 {% if drop.monster.is_awakened %}
-                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% elif drop.monster.can_awaken %}
-                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% else %}
-                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% endif %}
             {% endfor %}
         </span>

--- a/herders/templates/herders/profile/data_logs/drops/monster_piece_drops.html
+++ b/herders/templates/herders/profile/data_logs/drops/monster_piece_drops.html
@@ -5,7 +5,7 @@
 {% for drop in drops %}
 <a href="{% url 'bestiary:detail' monster_slug=drop.monster.bestiary_slug %}" class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ drop.monster.name }} pieces">
     <div>
-        <img src="{{ img_url_prefix }}monsters/{{ drop.monster.image_filename }}" class="monster-thumb"/>
+        <img src="{{ img_url_prefix }}monsters/{{ drop.monster.image_filename }}" class="monster-thumb" loading="lazy" />
         <span class="image-plus image-plus-main fa fa-puzzle-piece"></span>
         <span class="image-plus image-plus-right">x{{ drop.quantity }}</span>
     </div>

--- a/herders/templates/herders/profile/data_logs/drops/rune_drops.html
+++ b/herders/templates/herders/profile/data_logs/drops/rune_drops.html
@@ -10,9 +10,9 @@
         </div>
         {% for x in drop.stars|get_range %}
             {% if drop.level == 15 %}
-            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" />
+            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" loading="lazy" />
             {% else %}
-            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
             {% endif %}
         {% endfor %}
         <span class="image-plus image-plus-right">{{ drop.get_main_stat_display }}</span >

--- a/herders/templates/herders/profile/data_logs/drops/rune_popover.html
+++ b/herders/templates/herders/profile/data_logs/drops/rune_popover.html
@@ -23,7 +23,7 @@
         {% endif %}
         {% if drop.value %}
             <li class="mana-crystals">
-                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" /> {{ drop.value }}
+                <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" loading="lazy" /> {{ drop.value }}
             </li>
         {% endif %}
         {% if drop.efficiency %}<li>Eff: {{ drop.efficiency|floatformat:1 }}%</li>{% endif %}

--- a/herders/templates/herders/profile/data_logs/drops/secret_dungeon_drops.html
+++ b/herders/templates/herders/profile/data_logs/drops/secret_dungeon_drops.html
@@ -5,7 +5,7 @@
 {% for drop in drops %}
     {% with monster=drop.level.dungeon.secretdungeon.monster %}
         <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ monster.get_element_display }} {{ monster.name }} Secret Dungeon">
-            <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" class="monster-thumb"/>
+            <img src="{{ img_url_prefix }}monsters/{{ monster.image_filename }}" class="monster-thumb" loading="lazy" />
             <span class="image-plus image-plus-right">SD</span>
         </div>
     {% endwith %}

--- a/herders/templates/herders/profile/data_logs/drops/summary/items.html
+++ b/herders/templates/herders/profile/data_logs/drops/summary/items.html
@@ -9,7 +9,7 @@
     <div class="panel-body">
         {% for item in items %}
             <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ item.name }} x{{ item.count|intcomma }}">
-                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="monster-thumb" alt="{{ item.name }} Icon"/>
+                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="monster-thumb" alt="{{ item.name }} Icon" loading="lazy" />
                 <span class="image-plus image-plus-right">{{ item.count|humanize_number }}</span>
             </div>
         {% empty %}

--- a/herders/templates/herders/profile/data_logs/drops/summary/monsters.html
+++ b/herders/templates/herders/profile/data_logs/drops/summary/monsters.html
@@ -9,15 +9,15 @@
     <div class="panel-body">
         {% for monster in monsters %}
             <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ monster.stars }}⭐ {% if not monster.is_awakened %}{{ monster.element }}{% endif %} {{ monster.name }} x{{ monster.count }}">
-                <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb"/>
+                <img src="{{ img_url_prefix }}monsters/{{ monster.icon }}" alt="{{ monster.name }}" class="monster-thumb" loading="lazy" />
                 <span>
                     {% for x in monster.stars|get_range %}
                         {% if monster.is_awakened %}
-                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                         {% elif monster.can_awaken %}
-                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                         {% else %}
-                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                         {% endif %}
                     {% endfor %}
                 </span>

--- a/herders/templates/herders/profile/data_logs/drops/summary/runes.html
+++ b/herders/templates/herders/profile/data_logs/drops/summary/runes.html
@@ -15,9 +15,9 @@
                     </div>
                     {% for x in rune.stars|get_range %}
                         {% if rune.level == 15 %}
-                        <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" />
+                        <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" loading="lazy" />
                         {% else %}
-                        <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+                        <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
                         {% endif %}
                     {% endfor %}
                     <span class="image-plus image-plus-right">{{ rune.count|humanize_number }}</span >

--- a/herders/templates/herders/profile/data_logs/rune_crafting.html
+++ b/herders/templates/herders/profile/data_logs/rune_crafting.html
@@ -29,9 +29,9 @@
                 </div>
                 {% for x in log.stars|get_range %}
                     {% if log.level == 15 %}
-                    <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" />
+                    <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" loading="lazy" />
                     {% else %}
-                    <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+                    <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
                     {% endif %}
                 {% endfor %}
                 <span class="image-plus image-plus-right">{{ log.get_main_stat_display }}</span >

--- a/herders/templates/herders/profile/data_logs/summons/dashboard.html
+++ b/herders/templates/herders/profile/data_logs/summons/dashboard.html
@@ -41,7 +41,7 @@
                         <a href="{% url 'herders:data_log_summons_table' profile_name=profile_name %}" class="list-group-item">View As Table</a>
                         {% for item in item_list %}
                             <a href="{% url 'herders:data_log_summons_detail' profile_name=profile_name slug=item.slug %}" class="list-group-item">
-                                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="image-inline" alt="{{ item.name }} icon" />
+                                <img src="{{ img_url_prefix }}items/{{ item.icon }}" class="image-inline" alt="{{ item.name }} icon" loading="lazy" />
                                 {{ item }}
                             </a>
                         {% endfor %}

--- a/herders/templates/herders/profile/data_logs/summons/table.html
+++ b/herders/templates/herders/profile/data_logs/summons/table.html
@@ -32,21 +32,21 @@
             <td>{{ log.timestamp }}</td>
             <td>
                 <div class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ log.item.name }}">
-                    <img src="{{ img_url_prefix }}items/{{ log.item.icon }}" class="monster-thumb"/>
+                    <img src="{{ img_url_prefix }}items/{{ log.item.icon }}" class="monster-thumb" loading="lazy" />
                 </div>
             </td>
             <td>
                 <a href="{% url 'bestiary:detail' monster_slug=log.monster.bestiary_slug %}" class="monster-image" data-toggle="tooltip" data-placement="top" title="{{ log.monster.get_element_display }} {{ log.monster.name }}">
                     <div>
-                        <img src="{{ img_url_prefix }}monsters/{{ log.monster.image_filename }}" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/{{ log.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                         <span>
                             {% for x in log.grade|get_range %}
                                 {% if log.monster.is_awakened %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% elif log.monster.can_awaken %}
-                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% else %}
-                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endif %}
                             {% endfor %}
                         </span>

--- a/herders/templates/herders/profile/fusion/base.html
+++ b/herders/templates/herders/profile/fusion/base.html
@@ -15,7 +15,7 @@
         {% for fusion in fusions %}
         <li>
             <a class="fusion-tab" data-fusion="{{ fusion.product.bestiary_slug }}">
-                <img src="{{ img_url_prefix }}monsters/{{ fusion.product.image_filename }}" class="monster-inline"/>
+                <img src="{{ img_url_prefix }}monsters/{{ fusion.product.image_filename }}" class="monster-inline" loading="lazy" />
                 {{ fusion.product.base_stars }}<span class="glyphicon glyphicon-star"></span> {{ fusion.product.name }}{% if fusion.acquired %} - <span class="glyphicon glyphicon-ok-circle"></span> Acquired!{% endif %}
             </a>
         </li>

--- a/herders/templates/herders/profile/fusion/fusion_detail.html
+++ b/herders/templates/herders/profile/fusion/fusion_detail.html
@@ -5,15 +5,15 @@
 {% static 'herders/images/' as img_url_prefix %}
 <div class="monster-box">
     <div class="monster-box-thumb">
-        <img src="{{ img_url_prefix }}monsters/{{ fusion.instance.image_filename }}"/>
+        <img src="{{ img_url_prefix }}monsters/{{ fusion.instance.image_filename }}" loading="lazy" />
         <span>
             {% for x in fusion.instance.base_stars|get_range %}
                 {% if fusion.instance.is_awakened %}
-                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% elif fusion.instance.can_awaken %}
-                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% else %}
-                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                 {% endif %}
             {% endfor %}
         </span>
@@ -23,9 +23,9 @@
 <div class="bestiary-name">
     <h1>
         {{fusion.instance.name }}
-        <small><img src="{{ img_url_prefix }}elements/{{fusion.instance.element }}.png" style="height:1em"/>{{fusion.instance.get_archetype_display }}</small>
+        <small><img src="{{ img_url_prefix }}elements/{{fusion.instance.element }}.png" style="height:1em" loading="lazy" />{{fusion.instance.get_archetype_display }}</small>
     </h1>
-    <p>Fusion Cost: <img src="{{ img_url_prefix }}items/mana.png" style="height: 1em;"/> {{ fusion.cost }}</p>
+    <p>Fusion Cost: <img src="{{ img_url_prefix }}items/mana.png" style="height: 1em;" loading="lazy" /> {{ fusion.cost }}</p>
 </div>
 
 <div class="clearfix"></div>
@@ -54,15 +54,15 @@
                     <td class="monster-image">
                         <div class="pull-left">
                             <a href="{% url 'bestiary:detail' monster_slug=ingredient.instance.bestiary_slug %}">
-                                <img src="{{ img_url_prefix }}monsters/{{ ingredient.instance.image_filename }}" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/{{ ingredient.instance.image_filename }}" class="monster-thumb" loading="lazy" />
                                 <span>
                                     {% for x in fusion.stars|get_range %}
                                         {% if ingredient.instance.is_awakened %}
-                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% elif ingredient.instance.can_awaken %}
-                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% else %}
-                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% endif %}
                                     {% endfor %}
                                 </span>
@@ -90,7 +90,7 @@
                     <td class="monster-sources">
                         {% for source in ingredient.instance.awakens_from.source.all %}
                             {% if source.icon_filename %}
-                            <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}"
+                            <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}" loading="lazy" 
                                  class="monster-source" data-toggle="tooltip" data-placement="top" data-container="body" title="{{ source.name }}" />
                             {% else %}
                             <span class="monster-source"><span>{{ source }}</span></span>
@@ -134,15 +134,15 @@
                                     {% if is_owner %}
                                         <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=owned.pk.hex %}?next={{ return_path }}#edit">
                                     {% endif %}
-                                        <img src="{{ img_url_prefix }}monsters/{{ owned.monster.image_filename }}" class="monster-thumb"/>
+                                        <img src="{{ img_url_prefix }}monsters/{{ owned.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                         <span>
                                             {% for x in owned.stars|get_range %}
                                                 {% if owned.monster.is_awakened %}
-                                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% elif owned.monster.can_awaken %}
-                                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% else %}
-                                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% endif %}
                                             {% endfor %}
                                         </span>
@@ -159,7 +159,7 @@
                         {% if ingredient.pieces %}
                             <div class="monster-image pull-left">
                                 <div>
-                                    <img src="{{ img_url_prefix }}monsters/{{ ingredient.pieces.monster.image_filename }}" class="monster-thumb"/>
+                                    <img src="{{ img_url_prefix }}monsters/{{ ingredient.pieces.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                     <span class="image-plus image-plus-main fa fa-puzzle-piece"></span>
                                     <span class="image-plus image-plus-right">x{{ ingredient.pieces.pieces }}</span>
                                 </div>
@@ -167,7 +167,7 @@
                         {% endif %}
                         {% if ingredient.shrine %}
                             <div class="monster-image pull-left">
-                                <img src="{{ img_url_prefix }}buildings/monster_shrine.png" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}buildings/monster_shrine.png" class="monster-thumb" loading="lazy" />
                                 <span class="image-plus image-plus-main">{{ ingredient.shrine }}</span>
                             </div>
                         {% endif %}

--- a/herders/templates/herders/profile/monster_inventory/list.html
+++ b/herders/templates/herders/profile/monster_inventory/list.html
@@ -66,7 +66,7 @@
                             <th>Notes</th>
                             <th data-sorter="false" data-columnSelector="false">Teams</th>
                             <th data-sorter="false">Labels</th>
-                            <th class="monster-info-icons-column" data-selector-name="Fusion Food"><img src="{{ img_url_prefix }}icons/fusion.png" loading="lazy" data-toggle="tooltip" data-placement="top" title="Used in monster fusion" loading="lazy" /></th>
+                            <th class="monster-info-icons-column" data-selector-name="Fusion Food"><img src="{{ img_url_prefix }}icons/fusion.png" data-toggle="tooltip" data-placement="top" title="Used in monster fusion" loading="lazy" /></th>
                             <th class="monster-info-icons-column" data-selector-name="Locked"><span class="glyphicon glyphicon-lock"></span></th>
                             <th class="monster-info-icons-column" data-selector-name="Fodder"><span class="fa fa-birthday-cake" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Marked as food"></span></th>
                             <th class="monster-info-icons-column" data-selector-name="In Storage"><span class="fa fa-bed" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="In Monster Storage"></span></th>

--- a/herders/templates/herders/profile/monster_inventory/list.html
+++ b/herders/templates/herders/profile/monster_inventory/list.html
@@ -66,7 +66,7 @@
                             <th>Notes</th>
                             <th data-sorter="false" data-columnSelector="false">Teams</th>
                             <th data-sorter="false">Labels</th>
-                            <th class="monster-info-icons-column" data-selector-name="Fusion Food"><img src="{{ img_url_prefix }}icons/fusion.png"  data-toggle="tooltip" data-placement="top" title="Used in monster fusion"/></th>
+                            <th class="monster-info-icons-column" data-selector-name="Fusion Food"><img src="{{ img_url_prefix }}icons/fusion.png" loading="lazy" data-toggle="tooltip" data-placement="top" title="Used in monster fusion" loading="lazy" /></th>
                             <th class="monster-info-icons-column" data-selector-name="Locked"><span class="glyphicon glyphicon-lock"></span></th>
                             <th class="monster-info-icons-column" data-selector-name="Fodder"><span class="fa fa-birthday-cake" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="Marked as food"></span></th>
                             <th class="monster-info-icons-column" data-selector-name="In Storage"><span class="fa fa-bed" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="In Monster Storage"></span></th>

--- a/herders/templates/herders/profile/monster_inventory/monster_box_snippet.html
+++ b/herders/templates/herders/profile/monster_inventory/monster_box_snippet.html
@@ -12,9 +12,9 @@
             {% include 'herders/profile/monster_portrait_large.html' with instance=instance only%}
             <div class="image-plus-icon">
                 {% if instance.monster.fusion_food and not instance.ignore_for_fusion %}
-                    <img src="{{ img_url_prefix }}icons/fusion.png" />
+                    <img src="{{ img_url_prefix }}icons/fusion.png" loading="lazy" />
                 {% elif instance.monster.fusion_food and instance.ignore_for_fusion %}
-                    <img src="{{ img_url_prefix }}icons/fusion_ignored.png" />
+                    <img src="{{ img_url_prefix }}icons/fusion_ignored.png" loading="lazy" />
                 {% endif %}
                 {% if instance.ignore_for_fusion %}
                     <span class="fa-stack">

--- a/herders/templates/herders/profile/monster_inventory/monster_list_row_snippet.html
+++ b/herders/templates/herders/profile/monster_inventory/monster_list_row_snippet.html
@@ -27,7 +27,7 @@
         {% endif %}
     </td>
     <td class="monster-element">
-        <img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" />
+        <img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" loading="lazy" />
         <span>{{ instance.monster.element }}</span>
     </td>
     <td>{{ instance.monster.get_archetype_display }}</td>
@@ -45,7 +45,7 @@
     <td class="monster-leader-skill">
         {% if instance.monster.leader_skill %}
         <div>
-            <img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}"
+            <img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}" loading="lazy"
                  data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="Leader Skill" data-content="{{ instance.monster.leader_skill.skill_string }}" />
             <span class="image-plus image-plus-top-left">{{ instance.monster.leader_skill.amount }}%</span>
         </div>
@@ -54,21 +54,21 @@
     <td class="monster-awakens">
         {% if instance.monster.awakens_from %}
         <a href="{% url 'bestiary:detail' monster_slug=instance.monster.awakens_from.bestiary_slug %}">
-            <img src="{{ img_url_prefix }}monsters/{{ instance.monster.awakens_from.image_filename }}" class="monster-thumb"/> {{ instance.monster.awakens_from.name }}
+            <img src="{{ img_url_prefix }}monsters/{{ instance.monster.awakens_from.image_filename }}" class="monster-thumb" loading="lazy"/> {{ instance.monster.awakens_from.name }}
         </a>
         {% endif %}
     </td>
     <td class="monster-awakens">
         {% if instance.monster.awakens_to %}
         <a href="{% url 'bestiary:detail' monster_slug=instance.monster.awakens_to.bestiary_slug %}">
-            <img src="{{ img_url_prefix }}monsters/{{ instance.monster.awakens_to.image_filename }}" class="monster-thumb"/> {{ instance.monster.awakens_to.name }}
+            <img src="{{ img_url_prefix }}monsters/{{ instance.monster.awakens_to.image_filename }}" class="monster-thumb" loading="lazy"/> {{ instance.monster.awakens_to.name }}
         </a>
         {% endif %}
     </td>
     <td class="monster-awaken-materials">
         {% for skill in instance.monster.skills.all %}
             <div class="monster-skill-thumb pull-left skill-popover" data-skill-id="{{ skill.pk }}" title="{{ skill.name }}" data-placement="top">
-                <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" />
+                <img src="{{ img_url_prefix }}skills/{{ skill.icon_filename }}" loading="lazy" />
                 {% if forloop.counter == 1 %}
                 <span class="image-plus image-plus-right">{{ instance.skill_1_level }}/{{ skill.max_level }}</span>
                 {% elif forloop.counter == 2 %}
@@ -84,7 +84,7 @@
     <td>
         {% if instance.skill_ups_to_max > 0 %}
         <div class="monster-image">
-            <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb"/>
+            <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb" loading="lazy"/>
             <span class="image-plus image-plus-main">{{ instance.skill_ups_to_max }}</span>
         </div>
         {% else %}
@@ -144,10 +144,10 @@
     </td>
     <td class="monster-info-icons-column">
         {% if instance.monster.fusion_food and not instance.ignore_for_fusion %}
-            <img src="{{ img_url_prefix }}icons/fusion.png"  data-toggle="tooltip" data-placement="top" title="Used in monster fusion"/>
+            <img src="{{ img_url_prefix }}icons/fusion.png"  data-toggle="tooltip" data-placement="top" title="Used in monster fusion" loading="lazy"/>
             <span class="hidden">0</span>
         {% elif instance.monster.fusion_food and instance.ignore_for_fusion %}
-            <img src="{{ img_url_prefix }}icons/fusion_ignored.png"  data-toggle="tooltip" data-placement="top" title="Ignored for monster fusion"/>
+            <img src="{{ img_url_prefix }}icons/fusion_ignored.png"  data-toggle="tooltip" data-placement="top" title="Ignored for monster fusion" loading="lazy"/>
             <span class="hidden">1</span>
         {% else %}
             <span class="hidden">2</span>

--- a/herders/templates/herders/profile/monster_inventory/monster_piece_snippet.html
+++ b/herders/templates/herders/profile/monster_inventory/monster_piece_snippet.html
@@ -10,7 +10,7 @@
     <div class="monster-box-thumb">
         {% include 'bestiary/monster/portrait_large.html' with monster=piece.monster only %}
         <div class="image-plus-icon">
-            {% if piece.monster.fusion_food %}<img src="{{ img_url_prefix }}icons/fusion.png" />{% endif %}
+            {% if piece.monster.fusion_food %}<img src="{{ img_url_prefix }}icons/fusion.png" loading="lazy" />{% endif %}
         </div>
         <span class="image-plus image-plus-left">x{{ piece.pieces }} Pieces</span>
     </div>

--- a/herders/templates/herders/profile/monster_portrait_large.html
+++ b/herders/templates/herders/profile/monster_portrait_large.html
@@ -2,6 +2,6 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <div class="monster-box-thumb">
-    <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" alt="{{ instance.monster.name }} portrait"/>
+    <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" alt="{{ instance.monster.name }} portrait" loading="lazy" />
     {% include './monster_portrait_stars.html' %}
 </div>

--- a/herders/templates/herders/profile/monster_portrait_small.html
+++ b/herders/templates/herders/profile/monster_portrait_small.html
@@ -2,6 +2,6 @@
 {% static 'herders/images/' as img_url_prefix %}
 
 <div class="monster-image">
-    <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-thumb" alt="{{ instance.monster.name }} portrait" />
+    <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-thumb" alt="{{ instance.monster.name }} portrait" loading="lazy" />
     {% include './monster_portrait_stars.html' %}
 </div>

--- a/herders/templates/herders/profile/monster_portrait_stars.html
+++ b/herders/templates/herders/profile/monster_portrait_stars.html
@@ -5,17 +5,17 @@
     {% for x in instance.stars|get_range %}
         {% if instance.monster.can_awaken %}
             {% if instance.monster.awaken_level == instance.monster.AWAKEN_LEVEL_AWAKENED %}
-                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% elif instance.monster.awaken_level == instance.monster.AWAKEN_LEVEL_SECOND %}
-                <img src="{{ img_url_prefix }}stars/star-awakened2.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-awakened2.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% else %}
-                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% endif %}
         {% else %}
             {% if instance.monster.awaken_level == instance.monster.AWAKEN_LEVEL_INCOMPLETE %}
-                <img src="{{ img_url_prefix }}stars/star-incomplete.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-incomplete.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% else %}
-                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star"/>
+                <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" alt="star" loading="lazy" />
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/herders/templates/herders/profile/monster_view/awaken_form.html
+++ b/herders/templates/herders/profile/monster_view/awaken_form.html
@@ -20,7 +20,7 @@
                 {% else %}
                     border: 5px solid red
                 {% endif %}
-                "/>
+                " loading="lazy" />
                 <span class="image-plus image-plus-right">{{ count.qty }}</span>
             </div>
         {% endfor %}

--- a/herders/templates/herders/profile/monster_view/base.html
+++ b/herders/templates/herders/profile/monster_view/base.html
@@ -17,7 +17,7 @@
 
     {% if is_owner%}
         <ul class="dropdown-menu navmenu-nav">
-            <li><a><img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-inline" /> {% if instance.custom_name %}{{ instance.custom_name }}{% else %}{{ instance.monster.name }}{% endif %}</a></li>
+            <li><a><img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-inline" loading="lazy" /> {% if instance.custom_name %}{{ instance.custom_name }}{% else %}{{ instance.monster.name }}{% endif %}</a></li>
             <li><a class="monster-edit" data-instance-id="{{ instance.pk.hex }}"><span class="glyphicon glyphicon-edit"></span> Edit</a></li>
             <li><a class="monster-copy" data-instance-id="{{ instance.pk.hex }}"><span class="glyphicon glyphicon-copy"></span> Copy</a></li>
             <li><a class="monster-power-up" data-instance-id="{{ instance.pk.hex }}"><span class="glyphicon glyphicon-arrow-up"></span> Power Up</a></li>

--- a/herders/templates/herders/profile/monster_view/notes_info.html
+++ b/herders/templates/herders/profile/monster_view/notes_info.html
@@ -14,9 +14,9 @@
             <span class="image-plus image-plus-right">{% if instance.is_max_level %}MAX{% endif %}{{ instance.level }}</span>
             <div class="image-plus-icon">
                 {% if instance.monster.fusion_food and not instance.ignore_for_fusion %}
-                    <img src="{{ img_url_prefix }}icons/fusion.png" />
+                    <img src="{{ img_url_prefix }}icons/fusion.png" loading="lazy" />
                 {% elif instance.monster.fusion_food and instance.ignore_for_fusion %}
-                    <img src="{{ img_url_prefix }}icons/fusion_ignored.png" />
+                    <img src="{{ img_url_prefix }}icons/fusion_ignored.png" loading="lazy" />
                 {% endif %}
                 {% if instance.ignore_for_fusion %}
                     <span class="fa-stack">
@@ -44,7 +44,7 @@
             {% else %}
                 <h1>{{ instance.monster.name }}</h1>
             {% endif %}
-            <p class="lead"><img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" style="height:1em"/> {{ instance.monster.get_archetype_display }}</p>
+            <p class="lead"><img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" style="height:1em" loading="lazy" /> {{ instance.monster.get_archetype_display }}</p>
         </div>
     </div>
     <table class="table table-condensed table-bordered">
@@ -62,10 +62,10 @@
                 <td>
                     <span class="monster-image">
                         <a href="{% url 'bestiary:detail' monster_slug=awakened.bestiary_slug %}" target="_blank">
-                            <img src="{{ img_url_prefix }}monsters/{{ awakened.image_filename }}" class="monster-thumb"/>
+                            <img src="{{ img_url_prefix }}monsters/{{ awakened.image_filename }}" class="monster-thumb" loading="lazy" />
                             <span>
                                 {% for x in awakened.base_stars|get_range %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endfor %}
                             </span>
                         </a>
@@ -109,7 +109,7 @@
             <td class="monster-sources">
                 {% for source in instance.monster.source.all %}
                     {% if source.icon_filename %}
-                    <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}"
+                    <img src="{{ img_url_prefix }}icons/{{ source.icon_filename }}" loading="lazy" 
                          class="monster-source" data-toggle="tooltip" data-placement="top" data-container="body" title="{{ source.name }}" />
                     {% else %}
                     <span class="monster-source"><span>{{ source }}</span></span>
@@ -124,15 +124,15 @@
                     {% for fusion in fusion_ingredient_in %}
                     <div class="monster-image">
                         <a href="{% url 'herders:fusion' profile_name=profile_name %}#{{ fusion.product.bestiary_slug }}">
-                            <img src="{{ img_url_prefix }}monsters/{{ fusion.product.image_filename }}" class="monster-thumb"/>
+                            <img src="{{ img_url_prefix }}monsters/{{ fusion.product.image_filename }}" class="monster-thumb" loading="lazy" />
                             <span>
                                 {% for x in fusion.product.base_stars|get_range %}
                                     {% if fusion.product.is_awakened %}
-                                        <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% elif fusion.product.can_awaken %}
-                                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% else %}
-                                        <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% endif %}
                                 {% endfor %}
                             </span>
@@ -148,15 +148,15 @@
                 <td>
                     <div class="monster-image">
                         <a href="{% url 'herders:fusion' profile_name=profile_name %}#{{ fusion_product_of.product.bestiary_slug }}">
-                            <img src="{{ img_url_prefix }}monsters/{{ fusion_product_of.product.image_filename }}" class="monster-thumb"/>
+                            <img src="{{ img_url_prefix }}monsters/{{ fusion_product_of.product.image_filename }}" class="monster-thumb" loading="lazy" />
                             <span>
                                 {% for x in fusion_product_of.product.base_stars|get_range %}
                                     {% if fusion_product_of.product.is_awakened %}
-                                        <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% elif fusion_product_of.product.can_awaken %}
-                                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% else %}
-                                        <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                        <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                     {% endif %}
                                 {% endfor %}
                             </span>
@@ -199,7 +199,7 @@
                 {% else %}
                     {% if skillups.devilmon %}
                     <div class="monster-image">
-                        <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/devilmon_dark.png" class="monster-thumb" loading="lazy" />
                         <span class="image-plus image-plus-main">{{ skillups.devilmon }}</span>
                     </div>
                     {% endif %}
@@ -208,15 +208,15 @@
                             <div class="monster-image pull-left monster-popover" data-instance-id="{{ food_mon.pk.hex }}" title="{{ food_mon.monster.name }} - {{ food_mon.monster.get_element_display }} {% if food_mon.monster.awakens_from %}{{ food_mon.monster.awakens_from.name }}{% endif %}">
                                 <div>
                                     <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=food_mon.pk.hex %}?next={{ return_path }}#edit">
-                                        <img src="{{ img_url_prefix }}monsters/{{ food_mon.monster.image_filename }}" class="monster-thumb"/>
+                                        <img src="{{ img_url_prefix }}monsters/{{ food_mon.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                         <span>
                                             {% for x in food_mon.stars|get_range %}
                                                 {% if food_mon.monster.is_awakened %}
-                                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% elif food_mon.monster.can_awaken %}
-                                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% else %}
-                                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                                 {% endif %}
                                             {% endfor %}
                                         </span>
@@ -233,7 +233,7 @@
                         {% for piece in skillups.pieces %}
                             <div class="monster-image pull-left">
                                 <div>
-                                    <img src="{{ img_url_prefix }}monsters/{{ piece.monster.image_filename }}" class="monster-thumb"/>
+                                    <img src="{{ img_url_prefix }}monsters/{{ piece.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                     <span class="image-plus image-plus-main fa fa-puzzle-piece"></span>
                                     <span class="image-plus image-plus-right">x{{ piece.pieces }}</span>
                                 </div>
@@ -242,7 +242,7 @@
                     {% endif %}
                     {% if skillups.family_shrine %}
                     <div class="monster-image">
-                        <img src="{{ img_url_prefix }}buildings/monster_shrine.png" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}buildings/monster_shrine.png" class="monster-thumb" loading="lazy" />
                         <span class="image-plus image-plus-main">{{ skillups.family_shrine }}</span>
                     </div>
                     {% endif %}

--- a/herders/templates/herders/profile/monster_view/runes_artifact_row.html
+++ b/herders/templates/herders/profile/monster_view/runes_artifact_row.html
@@ -1,6 +1,6 @@
 <tr {% if artifact %}class="artifact-popover" data-artifact-id="{{ artifact.pk.hex }}"{% endif %}>
     <td style="vertical-align:middle;width:115px">
-        <img src="{{ img_url_prefix }}artifacts/{{ slot }}.png" alt="{{ slot }} icon">
+        <img src="{{ img_url_prefix }}artifacts/{{ slot }}.png" alt="{{ slot }} icon" loading="lazy" >
         {{ slot|capfirst }}
     </td>
     <td>

--- a/herders/templates/herders/profile/monster_view/skills.html
+++ b/herders/templates/herders/profile/monster_view/skills.html
@@ -5,7 +5,7 @@
 <div class="col-lg-12">
     <div class="panel panel-default">
         <div class="panel-body">
-            <div class="monster-skill-thumb pull-left"><img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}" /></div>
+            <div class="monster-skill-thumb pull-left"><img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}" loading="lazy" /></div>
             <h4 class="list-group-item-heading">Leader Skill</h4>
             <div class="list-group-item-text">
                 {{ instance.monster.leader_skill.skill_string }}
@@ -25,7 +25,7 @@
         <ul class="list-group">
             <li class="list-group-item">
                 <div class="monster-skill-thumb pull-left">
-                    <img src="{{ img_url_prefix }}skills/{{ skill.skill.icon_filename }}" />
+                    <img src="{{ img_url_prefix }}skills/{{ skill.skill.icon_filename }}" loading="lazy" />
                     <span class="image-plus image-plus-right">{{ skill.level }}/{{ skill.skill.max_level }}</span>
                 </div>
                 <p>
@@ -57,7 +57,7 @@
                 {% endif %}
                 {% for effect in skill.skill.skill_effect.all %}
                     {% if effect.icon_filename %}
-                    <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect pull-left"
+                    <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"  class="skill-effect pull-left" loading="lazy" 
                             data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}"
                             />
                     {% else %}

--- a/herders/templates/herders/profile/runes/craft_panel_fragment.html
+++ b/herders/templates/herders/profile/runes/craft_panel_fragment.html
@@ -25,7 +25,7 @@
                 <li>
                     <span class="label rune-label-{{ craft.get_quality_display|lower }}">
                         {% if 'Ancient' in craft.get_type_display %}
-                            <img src="{{ img_url_prefix }}runes/ancient.png" class="inline-icon" alt="Ancient icon" />
+                            <img src="{{ img_url_prefix }}runes/ancient.png" class="inline-icon" alt="Ancient icon" loading="lazy" />
                         {% endif %}
                         {{ craft.get_quality_display }}
                     </span>
@@ -35,7 +35,7 @@
                 </li>
                 {% if craft.value %}
                     <li>
-                        <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" alt="Mana icon"/>
+                        <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" alt="Mana icon" loading="lazy" />
                         {{ craft.value }}
                     </li>
                 {% endif %}

--- a/herders/templates/herders/profile/runes/inventory.html
+++ b/herders/templates/herders/profile/runes/inventory.html
@@ -15,7 +15,7 @@
                     <span class="glyphicon glyphicon-th"></span> Grid
                 </button>
                 <button class="btn btn-default rune-view-mode" data-mode="crafts">
-                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" />
+                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" loading="lazy" />
                 </button>
             </div>
 

--- a/herders/templates/herders/profile/runes/inventory_crafts.html
+++ b/herders/templates/herders/profile/runes/inventory_crafts.html
@@ -15,7 +15,7 @@
                     <span class="glyphicon glyphicon-th"></span> Grid
                 </button>
                 <button class="btn btn-default rune-view-mode active" data-mode="crafts">
-                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" />
+                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" loading="lazy" />
                 </button>
             </div>
         </div>

--- a/herders/templates/herders/profile/runes/inventory_grid.html
+++ b/herders/templates/herders/profile/runes/inventory_grid.html
@@ -16,7 +16,7 @@
                     <span class="glyphicon glyphicon-th"></span> Grid
                 </button>
                 <button class="btn btn-default rune-view-mode" data-mode="crafts">
-                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" />
+                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" loading="lazy" />
                 </button>
             </div>
             <span class="pull-right">{{ filtered_count }} of {{ total_count }} rune{{ total_count|pluralize }}</span>
@@ -65,7 +65,7 @@
                     </td>
                     <td>{{ rune.slot }}</td>
                     <td>{{ rune.stars }}</td>
-                    <td>{% if rune.value %}<img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" /> {{ rune.value }}{% endif %}</td>
+                    <td>{% if rune.value %}<img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" loading="lazy" /> {{ rune.value }}{% endif %}</td>
                     <td>{% if rune.efficiency %}{{ rune.efficiency|floatformat:1 }}%{% endif %}</td>
                     <td>{% if rune.max_efficiency %}{{ rune.max_efficiency|floatformat:1 }}%{% endif %}</td>
                     <td>{% if rune.get_hp_pct %}<span {% if rune.main_stat == rune.STAT_HP_PCT %}class="lead"{% endif %}>{{ rune.get_hp_pct }}%</span>{% endif %}</td>
@@ -84,15 +84,15 @@
                         <span class="hidden">{{ rune.assigned_to.monster.name }}-{{ rune.assigned_to.pk }}</span>
                         <div class="monster-image">
                             <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=rune.assigned_to.pk.hex %}" target="_blank">
-                                <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                 <span>
                                     {% for x in rune.assigned_to.stars|get_range %}
                                         {% if rune.assigned_to.monster.is_awakened %}
-                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% elif rune.assigned_to.monster.can_awaken %}
-                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% else %}
-                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% endif %}
                                     {% endfor %}
                                 </span>

--- a/herders/templates/herders/profile/runes/inventory_table.html
+++ b/herders/templates/herders/profile/runes/inventory_table.html
@@ -16,7 +16,7 @@
                     <span class="glyphicon glyphicon-th"></span> Grid
                 </button>
                 <button class="btn btn-default rune-view-mode" data-mode="crafts">
-                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" />
+                    <img src="{{ img_url_prefix }}runes/enchant_gem_legend.png" loading="lazy" />
                 </button>
             </div>
             <span class="pull-right">{{ filtered_count }} of {{ total_count }} rune{{ total_count|pluralize }}</span>
@@ -76,15 +76,15 @@
                         <span class="hidden">{{ rune.assigned_to.monster.name }}-{{ rune.assigned_to.pk }}</span>
                         <div class="monster-image">
                             <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=rune.assigned_to.pk.hex %}" target="_blank">
-                                <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                 <span>
                                     {% for x in rune.assigned_to.stars|get_range %}
                                         {% if rune.assigned_to.monster.is_awakened %}
-                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% elif rune.assigned_to.monster.can_awaken %}
-                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% else %}
-                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% endif %}
                                     {% endfor %}
                                 </span>

--- a/herders/templates/herders/profile/runes/rune_image_fragment.html
+++ b/herders/templates/herders/profile/runes/rune_image_fragment.html
@@ -9,9 +9,9 @@
         </div>
         {% for x in rune.stars|get_range %}
             {% if rune.level == 15 %}
-            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" />
+            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-awakened.png" loading="lazy" />
             {% else %}
-            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+            <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
             {% endif %}
         {% endfor %}
         <span class="image-plus image-plus-right">+{{ rune.level }}</span>

--- a/herders/templates/herders/profile/runes/rune_panel_fragment.html
+++ b/herders/templates/herders/profile/runes/rune_panel_fragment.html
@@ -35,15 +35,15 @@
             <div class="rune-assigned-to">
                 <div class="monster-image">
                     <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=rune.assigned_to.pk.hex %}" target="_blank">
-                        <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb"/>
+                        <img src="{{ img_url_prefix }}monsters/{{ rune.assigned_to.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                         <span>
                             {% for x in rune.assigned_to.stars|get_range %}
                                 {% if rune.assigned_to.monster.is_awakened %}
-                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% elif rune.assigned_to.monster.can_awaken %}
-                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% else %}
-                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                    <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                 {% endif %}
                             {% endfor %}
                         </span>
@@ -57,7 +57,7 @@
                 <li>
                     Orig: <span class="label rune-label-{{ rune.get_original_quality_display|lower }}">
                         {% if rune.ancient %}
-                            <img src="{{ img_url_prefix }}runes/ancient.png" class="inline-icon" alt="Ancient icon" />
+                            <img src="{{ img_url_prefix }}runes/ancient.png" class="inline-icon" alt="Ancient icon" loading="lazy" />
                         {% endif %}
                         {{ rune.get_original_quality_display }}
                     </span>
@@ -65,7 +65,7 @@
             {% endif %}
             {% if rune.value %}
                 <li class="mana-crystals">
-                    <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" /> {{ rune.value }}
+                    <img src="{{ img_url_prefix }}items/mana.png" class="inline-icon" loading="lazy" /> {{ rune.value }}
                     {% if rune.marked_for_sale %}<span class="glyphicon glyphicon-piggy-bank" data-toggle="tooltip" data-placement="top" title="Marked for Sale"></span>{% endif %}
                 </li>
             {% endif %}

--- a/herders/templates/herders/profile/storage/base.html
+++ b/herders/templates/herders/profile/storage/base.html
@@ -22,7 +22,7 @@
                             <h4 class="list-group-item-heading">{{ essence.name }}</h4>
                         </div>
                         <div class="list-group-item">
-                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_low.png" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_low.png" class="monster-inline pull-left" loading="lazy" />
                             <div class="inline-editable essence-input"
                                  data-type="number"
                                  data-name="{{ essence.field_name }}.low"
@@ -34,7 +34,7 @@
                             </div>
                         </div>
                         <div class="list-group-item">
-                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_mid.png" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_mid.png" class="monster-inline pull-left" loading="lazy" />
                             <div class="inline-editable essence-input"
                                  data-type="number"
                                  data-name="{{ essence.field_name }}.mid"
@@ -46,7 +46,7 @@
                             </div>
                         </div>
                         <div class="list-group-item">
-                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_high.png" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}/items/essence_{{ essence.element }}_high.png" class="monster-inline pull-left" loading="lazy" />
                             <div class="inline-editable essence-input"
                                  data-type="number"
                                  data-name="{{ essence.field_name }}.high"
@@ -75,7 +75,7 @@
                     <div class="panel panel-default">
                         <div class="panel-body condensed">
                             <p>{{ craft.name }}</p>
-                            <img src="{{ img_url_prefix }}items/craft_material_{{ craft.field_name }}.png" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}items/craft_material_{{ craft.field_name }}.png" class="monster-inline pull-left" loading="lazy" />
                             <div id="craft_{{ craft.field_name }}"
                                  class="inline-editable essence-input"
                                  data-type="number"
@@ -105,7 +105,7 @@
                     <div class="panel panel-default">
                         <div class="panel-body condensed">
                             <p>{{ monster.name }}</p>
-                            <img src="{{ img_url_prefix }}items/monster_{% if 'rainbowmon' in monster.field_name %}rainbowmon{% else %}{{ monster.field_name }}{% endif %}.png" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}items/monster_{% if 'rainbowmon' in monster.field_name %}rainbowmon{% else %}{{ monster.field_name }}{% endif %}.png" class="monster-inline pull-left" loading="lazy" />
                             <div id="craft_{{ monster.field_name }}"
                                  class="inline-editable essence-input"
                                  data-type="number"
@@ -135,7 +135,7 @@
                     <div class="panel panel-default">
                         <div class="panel-body condensed">
                             <p>{{ monster.name }}</p>
-                            <img src="{{ img_url_prefix }}monsters/{{ monster.img }}" class="monster-inline pull-left" />
+                            <img src="{{ img_url_prefix }}monsters/{{ monster.img }}" class="monster-inline pull-left" loading="lazy" />
                             <div id="monster_{{ monster.field_name }}" class="essence-input">
                                 {{ monster.qty }}
                             </div>

--- a/herders/templates/herders/profile/teams/team_detail.html
+++ b/herders/templates/herders/profile/teams/team_detail.html
@@ -29,12 +29,12 @@
             <td width="225px">Combined Team Buffs/Debuffs:</td>
             <td class="monster-skill-effects">
                 {% if team.leader.monster.leader_skill %}
-                <img src="{{ img_url_prefix }}skills/leader/{{ team.leader.monster.leader_skill.icon_filename }}"
+                <img src="{{ img_url_prefix }}skills/leader/{{ team.leader.monster.leader_skill.icon_filename }}" loading="lazy" 
                      data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="Leader Skill" data-content="{{ team.leader.monster.leader_skill.skill_string }}" />
                 {% endif %}
                 {% for effect in team_buffs %}
                 {% if effect.icon_filename %}
-                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"
+                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}" loading="lazy" 
                         data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}"/>
                 {% else %}
                 <span class="skill-effect {% if effect.is_buff %}skill-effect-buff{% else %}skill-effect-debuff{% endif %}" data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}">
@@ -65,15 +65,15 @@
                     <td class="monster-image monster-popover" data-instance-id="{{ team.leader.pk.hex }}" title="{{ team.leader }}">
                         <div>
                             <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=team.leader.pk.hex %}" target="_blank">
-                                <img src="{{ img_url_prefix }}monsters/{{ team.leader.monster.image_filename }}" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/{{ team.leader.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                 <span>
                                     {% for x in team.leader.stars|get_range %}
                                         {% if team.leader.monster.is_awakened %}
-                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% elif team.leader.monster.can_awaken %}
-                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% else %}
-                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% endif %}
                                     {% endfor %}
                                 </span>
@@ -94,13 +94,13 @@
                         {% endif %}
                     </td>
                     <td class="monster-element">
-                        <img src="{{ img_url_prefix }}elements/{{ team.leader.monster.element }}.png" />
+                        <img src="{{ img_url_prefix }}elements/{{ team.leader.monster.element }}.png" loading="lazy" />
                         <span>{{ team.leader.monster.element }}</span>
                     </td>
                     <td>{{ team.leader.monster.archetype|title }}</td>
                     <td class="monster-leader-skill">
                         {% if team.leader.monster.leader_skill %}
-                        <img src="{{ img_url_prefix }}skills/leader/{{ team.leader.monster.leader_skill.icon_filename }}"
+                        <img src="{{ img_url_prefix }}skills/leader/{{ team.leader.monster.leader_skill.icon_filename }}" loading="lazy" 
                              data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="Leader Skill" data-content="{{ team.leader.monster.leader_skill.skill_string }}" />
                         {% endif %}
                     </td>
@@ -113,7 +113,7 @@
                             {% endif %}
                             {% for effect in skill.skill_effect.all %}
                                 {% if effect.icon_filename %}
-                                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"
+                                <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}" loading="lazy" 
                                     data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}"/>
                                 {% else %}
                                     <span class="skill-effect {% if effect.is_buff %}skill-effect-buff{% else %}skill-effect-debuff{% endif %}" data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}">
@@ -134,15 +134,15 @@
                         <td class="monster-image monster-popover" data-instance-id="{{ instance.pk.hex }}" title="{{ instance }}">
                             <div>
                                 <a href="{% url 'herders:monster_instance_view' profile_name=profile_name instance_id=instance.pk.hex %}" target="_blank">
-                                <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-thumb"/>
+                                <img src="{{ img_url_prefix }}monsters/{{ instance.monster.image_filename }}" class="monster-thumb" loading="lazy" />
                                 <span>
                                     {% for x in instance.stars|get_range %}
                                         {% if instance.monster.is_awakened %}
-                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-awakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% elif instance.monster.can_awaken %}
-                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-unawakened.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% else %}
-                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" />
+                                            <img src="{{ img_url_prefix }}stars/star-fodder.png" class="monster-star monster-star-{{ forloop.counter }}" loading="lazy" />
                                         {% endif %}
                                     {% endfor %}
                                 </span>
@@ -163,13 +163,13 @@
                             {% endif %}
                         </td>
                         <td class="monster-element">
-                            <img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" />
+                            <img src="{{ img_url_prefix }}elements/{{ instance.monster.element }}.png" loading="lazy" />
                             <span>{{ instance.monster.element }}</span>
                         </td>
                         <td>{{ instance.monster.archetype|title }}</td>
                         <td class="monster-leader-skill">
                             {% if instance.monster.leader_skill %}
-                            <img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}"
+                            <img src="{{ img_url_prefix }}skills/leader/{{ instance.monster.leader_skill.icon_filename }}" loading="lazy" 
                                  data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="Leader Skill" data-content="{{ instance.monster.leader_skill.skill_string }}" />
                             {% endif %}
                         </td>
@@ -177,7 +177,7 @@
                             {% for skill in instance.monster.skills.all %}
                                 {% for effect in skill.skill_effect.all %}
                                     {% if effect.icon_filename %}
-                                        <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}"
+                                        <img src="{{ img_url_prefix }}buffs/{{ effect.icon_filename }}" loading="lazy" 
                                                 data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}"/>
                                     {% else %}
                                         <span class="skill-effect {% if effect.is_buff %}skill-effect-buff{% else %}skill-effect-debuff{% endif %}" data-toggle="popover" data-trigger="hover" data-placement="top" data-container="body" title="{{ effect.name }}" data-content="{{ effect.description }}">

--- a/herders/templates/herders/profile/teams/team_list.html
+++ b/herders/templates/herders/profile/teams/team_list.html
@@ -27,7 +27,7 @@
                 <a href="#{{ team.pk.hex }}" class="list-group-item team-link" data-team-id="{{ team.pk.hex }}">
                     {{ team.name }}
                     {% if team.favorite %}
-                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" />
+                        <img src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
                     {% endif %}
                 </a>
             {% empty %}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 django-debug-toolbar==1.10.1
+django-debug-toolbar-request-history==0.0.11

--- a/static/main/js/custom_filters.js
+++ b/static/main/js/custom_filters.js
@@ -54,3 +54,17 @@ function clean_query_params(part_url){
 
     return params.toString()
 }
+
+function clean_multi_slider_min_max_params(params, multiSliderParams){
+    // We only get multi slider values after using `clean_query_params` function
+    // Need to check if these values are equal min-max, if yes -> delete them from query
+    // Because there's no point in using Filter without any effect
+    for (let name of multiSliderParams) {
+        var [valueMin, valueMax] = params.get(name).split(',')
+        var el = $("input[name='" + name + "']")
+        if(el.attr("data-slider-min") === valueMin && el.attr("data-slider-max") === valueMax){
+            params.delete(name)    
+        }
+    }
+    return params.toString()
+}

--- a/swarfarm/settings.py
+++ b/swarfarm/settings.py
@@ -148,6 +148,17 @@ MIDDLEWARE = [
 if DEBUG:
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
 
+    DEBUG_TOOLBAR_PANELS = [
+        'ddt_request_history.panels.request_history.RequestHistoryPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+    ]
+    DEBUG_TOOLBAR_CONFIG = {
+        'RESULTS_STORE_SIZE': 1000,
+    }
+
 # Bugsnag
 if env('BUGSNAG_API_KEY'):
     MIDDLEWARE = ['bugsnag.django.middleware.BugsnagMiddleware'] + MIDDLEWARE

--- a/templates/autocomplete/bestiary_link.html
+++ b/templates/autocomplete/bestiary_link.html
@@ -3,6 +3,6 @@
 {% spaceless %}
     {% static 'herders/images/' as img_url_prefix %}
     <span data-redirect-url="{% url 'bestiary:detail' monster_slug=choice.bestiary_slug %}">
-        <img src="{{ img_url_prefix }}monsters/{{ choice.image_filename }}"/> <span>{{ choice }}</span>
+        <img src="{{ img_url_prefix }}monsters/{{ choice.image_filename }}" loading="lazy" /> <span>{{ choice }}</span>
     </span>
 {% endspaceless %}

--- a/templates/autocomplete/dungeon_choice.html
+++ b/templates/autocomplete/dungeon_choice.html
@@ -4,6 +4,6 @@
 {% spaceless %}
     {% static 'herders/images/' as img_url_prefix %}
     <span data-value="{{ choice.pk }}">
-        {% if choice.icon %}<img src="{{ img_url_prefix }}dungeons/{{ choice.icon }}"/>{% endif %} <span style="padding-left:5px">{{ choice }} ({{ choice.get_category_display }})</span>
+        {% if choice.icon %}<img src="{{ img_url_prefix }}dungeons/{{ choice.icon }}" loading="lazy" />{% endif %} <span style="padding-left:5px">{{ choice }} ({{ choice.get_category_display }})</span>
     </span>
 {% endspaceless %}

--- a/templates/autocomplete/gameitem_choice.html
+++ b/templates/autocomplete/gameitem_choice.html
@@ -4,6 +4,6 @@
 {% spaceless %}
     {% static 'herders/images/' as img_url_prefix %}
     <span data-value="{{ choice.pk }}">
-        <img src="{{ img_url_prefix }}items/{{ choice.icon }}"/> <span style="padding-left:5px">{{ choice }}</span>
+        <img src="{{ img_url_prefix }}items/{{ choice.icon }}" loading="lazy" /> <span style="padding-left:5px">{{ choice }}</span>
     </span>
 {% endspaceless %}

--- a/templates/autocomplete/monster_choice.html
+++ b/templates/autocomplete/monster_choice.html
@@ -4,6 +4,6 @@
 {% spaceless %}
     {% static 'herders/images/' as img_url_prefix %}
     <span data-value="{{ choice.pk }}">
-        <img src="{{ img_url_prefix }}monsters/{{ choice.image_filename }}"/> <span style="padding-left:5px">{{ choice }}</span>
+        <img src="{{ img_url_prefix }}monsters/{{ choice.image_filename }}" loading="lazy" /> <span style="padding-left:5px">{{ choice }}</span>
     </span>
 {% endspaceless %}

--- a/templates/autocomplete/monster_instance_choice.html
+++ b/templates/autocomplete/monster_instance_choice.html
@@ -3,6 +3,6 @@
 {% spaceless %}
     {% static 'herders/images/' as img_url_prefix %}
     <span data-value="{{ choice.pk }}">
-        <img src="{{ img_url_prefix }}monsters/{{ choice.monster.image_filename }}"/> <span style="padding-left:5px">{{ choice }}</span>
+        <img src="{{ img_url_prefix }}monsters/{{ choice.monster.image_filename }}" loading="lazy" /> <span style="padding-left:5px">{{ choice }}</span>
     </span>
 {% endspaceless %}

--- a/templates/autocomplete/rune_instance_choice.html
+++ b/templates/autocomplete/rune_instance_choice.html
@@ -10,7 +10,7 @@
                     <div class="rune-symbol {{ choice.get_type_display|lower }}"></div>
                 </div>
                 {% for x in choice.stars|get_range %}
-                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" />
+                <img class="star star-{{ forloop.counter }}" src="{{ img_url_prefix }}stars/star-unawakened.png" loading="lazy" />
                 {% endfor %}
                 <span class="image-plus image-plus-right">+{{ choice.level }}</span>
             </div>

--- a/templates/base/main_nav.html
+++ b/templates/base/main_nav.html
@@ -21,7 +21,7 @@
                 {% if user.is_authenticated %}
                     <li {% if view == 'profile' and is_owner %}class="active"{% endif %}>
                          <a href="{% url 'herders:profile_default' profile_name=user.username %}">
-                            <img src="{% static 'herders/images/icons/monster.png' %}" /> My Profile
+                            <img src="{% static 'herders/images/icons/monster.png' %}" loading="lazy" /> My Profile
                         </a>
                     </li>
                 {% endif %}
@@ -34,7 +34,7 @@
 
                 <li {% if view == 'dungeons' %}class="active"{% endif %}>
                     <a href="{% url 'bestiary:dungeons' %}">
-                        <img src="{% static 'herders/images/icons/battle.png' %}" alt="dungeon icon" /> Dungeons
+                        <img src="{% static 'herders/images/icons/battle.png' %}" alt="dungeon icon" loading="lazy" /> Dungeons
                     </a>
                 </li>
                 <li {% if view == 'data_reports' %}class="active"{% endif %}>

--- a/templates/crispy/skill_button_checkbox_select.html
+++ b/templates/crispy/skill_button_checkbox_select.html
@@ -18,7 +18,7 @@
             <div class="btn-group">
                 {% for choice in field.field.choices %}
                 <label class="btn btn-default btn-xs">
-                    <input type="checkbox"{% if choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}" {{ field.field.widget.attrs|flatatt }}><img src="{{ img_url_prefix }}/buffs/{{ choice.1 }}" />
+                    <input type="checkbox"{% if choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}" {{ field.field.widget.attrs|flatatt }}><img src="{{ img_url_prefix }}/buffs/{{ choice.1 }}" loading="lazy" />
                 </label>
                 {% endfor %}
             </div>


### PR DESCRIPTION
* Added Lazy loading for all images
* Cleaned up filter url (i.e. `name=&natural_stars=1,6&fusion_food=&skills__passive=&skills__aoe=&skills__cooltime=0,13&skills__hits=0,7&page=1&sort=` changed to `page=1`)
* Optimized Bestiary/Monsters Database calls

It also partially resolves given Feedback
> Whenever you click on bestiary, swarfarm load every monster before you can modify filter, making swarfam super slow especicaly on my phone, maybe, for the first loading, don't load monster and wait for the user to press apply to filter.

| Loading time [seconds]  | SWARFARM (before) | LOCAL (after) |
|---|---|-----|
| Bestiary  | 7  | 1  |  
| Monsters  | 6.5  | 3.5   |  
| Runes  | 10  | 8  |
| Artifacts | 1.5 | <0.5 |  